### PR TITLE
fix: added checks to exclude image links in entries

### DIFF
--- a/types/entry.ts
+++ b/types/entry.ts
@@ -1,8 +1,10 @@
 import { z } from "zod";
 
+const imageUrlPattern = /\.(jpeg|jpg|png|gif|bmp|svg|webp)$/i;
+
 export const Entry = z.object({
   id: z.string(),
   createdAt: z.number(),
-  content: z.string(),
+  content: z.string().refine((value) => !imageUrlPattern.test(value)),
 });
 export type Entry = z.infer<typeof Entry>;


### PR DESCRIPTION
Filtering image links using [Type Refinements](https://zod.dev/?id=type-refinements) and a regex of commonly found image extensions on the web
Closes #8 