### PR TITLE
feat: add favorite and delete actions to edit modal (#42)

### DIFF
--- a/popup/components/EntryDeleteAction.tsx
+++ b/popup/components/EntryDeleteAction.tsx
@@ -14,7 +14,7 @@ interface Props {
 export const EntryDeleteAction = ({ entryId }: Props) => {
   const favoriteEntryIdsSet = useAtomValue(favoriteEntryIdsSetAtom);
   const isFavoriteEntry = favoriteEntryIdsSet.has(entryId);
-  
+
   return (
     <ActionIcon
       sx={(theme) => commonActionIconSx({ theme, disabled: isFavoriteEntry })}
@@ -27,7 +27,7 @@ export const EntryDeleteAction = ({ entryId }: Props) => {
         }
       }}
     >
-    <IconTrash size="1rem" />
-  </ActionIcon>
+      <IconTrash size="1rem" />
+    </ActionIcon>
   );
 };

--- a/popup/components/EntryDeleteAction.tsx
+++ b/popup/components/EntryDeleteAction.tsx
@@ -1,4 +1,5 @@
 import { ActionIcon } from "@mantine/core";
+import { modals } from "@mantine/modals";
 import { IconTrash } from "@tabler/icons-react";
 import { useAtomValue } from "jotai";
 
@@ -22,6 +23,7 @@ export const EntryDeleteAction = ({ entryId }: Props) => {
 
         if (!isFavoriteEntry) {
           deleteEntries([entryId]);
+          modals.closeAll();
         }
       }}
     >

--- a/popup/components/EntryDeleteAction.tsx
+++ b/popup/components/EntryDeleteAction.tsx
@@ -1,0 +1,31 @@
+import { ActionIcon } from "@mantine/core";
+import { IconTrash } from "@tabler/icons-react";
+import { useAtomValue } from "jotai";
+
+import { favoriteEntryIdsSetAtom } from "~popup/states/atoms";
+import { deleteEntries } from "~utils/storage";
+import { commonActionIconSx } from "~utils/sx";
+
+interface Props {
+  entryId: string;
+}
+
+export const EntryDeleteAction = ({ entryId }: Props) => {
+  const favoriteEntryIdsSet = useAtomValue(favoriteEntryIdsSetAtom);
+  const isFavoriteEntry = favoriteEntryIdsSet.has(entryId);
+  
+  return (
+    <ActionIcon
+      sx={(theme) => commonActionIconSx({ theme, disabled: isFavoriteEntry })}
+      onClick={(e) => {
+        e.stopPropagation();
+
+        if (!isFavoriteEntry) {
+          deleteEntries([entryId]);
+        }
+      }}
+    >
+    <IconTrash size="1rem" />
+  </ActionIcon>
+  );
+};

--- a/popup/components/EntryFavoriteAction.tsx
+++ b/popup/components/EntryFavoriteAction.tsx
@@ -1,0 +1,44 @@
+import { ActionIcon } from "@mantine/core";
+import { IconStar, IconStarFilled } from "@tabler/icons-react";
+import { useAtomValue } from "jotai";
+import { favoriteEntryIdsSetAtom } from "~popup/states/atoms";
+import { addFavoriteEntryIds, deleteFavoriteEntryIds } from "~storage/favoriteEntryIds";
+import { lightOrDark } from "~utils/sx";
+
+interface Props {
+  entryId: string;
+}
+
+export const EntryFavoriteAction = ({ entryId }: Props) => {
+  const favoriteEntryIdsSet = useAtomValue(favoriteEntryIdsSetAtom);
+  const isFavoriteEntry = favoriteEntryIdsSet.has(entryId);
+
+  return (
+    <ActionIcon
+      sx={(theme) => ({
+        color: isFavoriteEntry ? theme.colors.yellow[5] : theme.colors.gray[5],
+        ":hover": {
+          color: isFavoriteEntry
+            ? theme.colors.yellow[5]
+            : lightOrDark(theme, theme.colors.gray[7], theme.colors.gray[3]),
+          backgroundColor: lightOrDark(
+            theme,
+            theme.colors.indigo[1],
+            theme.fn.darken(theme.colors.indigo[9], 0.3),
+          ),
+        },
+      })}
+      onClick={(e) => {
+        e.stopPropagation();
+
+        if (isFavoriteEntry) {
+          deleteFavoriteEntryIds([entryId]);
+        } else {
+          addFavoriteEntryIds([entryId]);
+        }
+      }}
+    >
+      {isFavoriteEntry ? <IconStarFilled size="1rem" /> : <IconStar size="1rem" />}
+    </ActionIcon>
+  );
+};

--- a/popup/components/EntryFavoriteAction.tsx
+++ b/popup/components/EntryFavoriteAction.tsx
@@ -1,6 +1,7 @@
 import { ActionIcon } from "@mantine/core";
 import { IconStar, IconStarFilled } from "@tabler/icons-react";
 import { useAtomValue } from "jotai";
+
 import { favoriteEntryIdsSetAtom } from "~popup/states/atoms";
 import { addFavoriteEntryIds, deleteFavoriteEntryIds } from "~storage/favoriteEntryIds";
 import { lightOrDark } from "~utils/sx";

--- a/popup/components/EntryRow.tsx
+++ b/popup/components/EntryRow.tsx
@@ -13,18 +13,14 @@ import { modals } from "@mantine/modals";
 import { IconEdit } from "@tabler/icons-react";
 import { useAtom, useAtomValue } from "jotai";
 
-import {
-  clipboardSnapshotAtom,
-  entryIdToTagsAtom,
-  nowAtom,
-} from "~popup/states/atoms";
+import { clipboardSnapshotAtom, entryIdToTagsAtom, nowAtom } from "~popup/states/atoms";
 import { updateClipboardSnapshot } from "~storage/clipboardSnapshot";
 import type { Entry } from "~types/entry";
 import { badgeDateFormatter } from "~utils/date";
 import { commonActionIconSx, defaultBorderColor, lightOrDark } from "~utils/sx";
 
-import { EntryFavoriteAction } from "./EntryFavoriteAction";
 import { EntryDeleteAction } from "./EntryDeleteAction";
+import { EntryFavoriteAction } from "./EntryFavoriteAction";
 import { EditEntryModalContent } from "./modals/EditEntryModalContent";
 import { TagBadge } from "./TagBadge";
 import { TagSelect } from "./TagSelect";

--- a/popup/components/EntryRow.tsx
+++ b/popup/components/EntryRow.tsx
@@ -10,22 +10,21 @@ import {
   useMantineTheme,
 } from "@mantine/core";
 import { modals } from "@mantine/modals";
-import { IconEdit, IconStar, IconStarFilled, IconTrash } from "@tabler/icons-react";
+import { IconEdit } from "@tabler/icons-react";
 import { useAtom, useAtomValue } from "jotai";
 
 import {
   clipboardSnapshotAtom,
   entryIdToTagsAtom,
-  favoriteEntryIdsSetAtom,
   nowAtom,
 } from "~popup/states/atoms";
 import { updateClipboardSnapshot } from "~storage/clipboardSnapshot";
-import { addFavoriteEntryIds, deleteFavoriteEntryIds } from "~storage/favoriteEntryIds";
 import type { Entry } from "~types/entry";
 import { badgeDateFormatter } from "~utils/date";
-import { deleteEntries } from "~utils/storage";
 import { commonActionIconSx, defaultBorderColor, lightOrDark } from "~utils/sx";
 
+import { EntryFavoriteAction } from "./EntryFavoriteAction";
+import { EntryDeleteAction } from "./EntryDeleteAction";
 import { EditEntryModalContent } from "./modals/EditEntryModalContent";
 import { TagBadge } from "./TagBadge";
 import { TagSelect } from "./TagSelect";
@@ -38,11 +37,8 @@ interface Props {
 export const EntryRow = ({ entry, selectedEntryIds }: Props) => {
   const theme = useMantineTheme();
   const now = useAtomValue(nowAtom);
-  const favoriteEntryIdsSet = useAtomValue(favoriteEntryIdsSetAtom);
   const entryIdToTags = useAtomValue(entryIdToTagsAtom);
   const [clipboardSnapshot, setClipboardSnapshot] = useAtom(clipboardSnapshotAtom);
-
-  const isFavoriteEntry = favoriteEntryIdsSet.has(entry.id);
 
   return (
     <Stack
@@ -139,44 +135,8 @@ export const EntryRow = ({ entry, selectedEntryIds }: Props) => {
           >
             <IconEdit size="1rem" />
           </ActionIcon>
-          <ActionIcon
-            sx={(theme) => ({
-              color: isFavoriteEntry ? theme.colors.yellow[5] : theme.colors.gray[5],
-              ":hover": {
-                color: isFavoriteEntry
-                  ? theme.colors.yellow[5]
-                  : lightOrDark(theme, theme.colors.gray[7], theme.colors.gray[3]),
-                backgroundColor: lightOrDark(
-                  theme,
-                  theme.colors.indigo[1],
-                  theme.fn.darken(theme.colors.indigo[9], 0.3),
-                ),
-              },
-            })}
-            onClick={(e) => {
-              e.stopPropagation();
-
-              if (isFavoriteEntry) {
-                deleteFavoriteEntryIds([entry.id]);
-              } else {
-                addFavoriteEntryIds([entry.id]);
-              }
-            }}
-          >
-            {isFavoriteEntry ? <IconStarFilled size="1rem" /> : <IconStar size="1rem" />}
-          </ActionIcon>
-          <ActionIcon
-            sx={(theme) => commonActionIconSx({ theme, disabled: isFavoriteEntry })}
-            onClick={(e) => {
-              e.stopPropagation();
-
-              if (!isFavoriteEntry) {
-                deleteEntries([entry.id]);
-              }
-            }}
-          >
-            <IconTrash size="1rem" />
-          </ActionIcon>
+          <EntryFavoriteAction entryId={entry.id} />
+          <EntryDeleteAction entryId={entry.id} />
         </Group>
       </Group>
       <Divider sx={(theme) => ({ borderColor: defaultBorderColor(theme) })} />

--- a/popup/components/modals/EditEntryModalContent.tsx
+++ b/popup/components/modals/EditEntryModalContent.tsx
@@ -21,6 +21,9 @@ import type { Entry } from "~types/entry";
 import { updateEntryContent } from "~utils/storage";
 import { lightOrDark } from "~utils/sx";
 
+import { EntryFavoriteAction } from "../EntryFavoriteAction";
+import { EntryDeleteAction } from "../EntryDeleteAction";
+
 const schema = z.object({
   content: z.string(),
 });
@@ -112,6 +115,8 @@ export const EditEntryModalContent = ({ entry }: Props) => {
                   )}
                 </Text>
                 <Group align="center" spacing="xs">
+                  <EntryFavoriteAction entryId={entry.id} />
+                  <EntryDeleteAction entryId={entry.id} />
                   <Button size="xs" variant="subtle" disabled={!isDirty} onClick={() => reset()}>
                     Reset
                   </Button>

--- a/popup/components/modals/EditEntryModalContent.tsx
+++ b/popup/components/modals/EditEntryModalContent.tsx
@@ -21,8 +21,8 @@ import type { Entry } from "~types/entry";
 import { updateEntryContent } from "~utils/storage";
 import { lightOrDark } from "~utils/sx";
 
-import { EntryFavoriteAction } from "../EntryFavoriteAction";
 import { EntryDeleteAction } from "../EntryDeleteAction";
+import { EntryFavoriteAction } from "../EntryFavoriteAction";
 
 const schema = z.object({
   content: z.string(),


### PR DESCRIPTION
Partially implements #42

#42 suggests adding the `tags`, `favorite` and `delete` actions in the Edit modal. In this PR, I have implemented the `favorite` and `delete` actions. The `tags` feature will be addressed in a separate PR to keep changes manageable and isolated.

Changes:
- Commit 1: Extracts `favorite` and `delete` actions into separate components (`EntryFavoriteAction` and `EntryDeleteAction`), adds these components in `EntryRow`
- Commit 2: Adds these components to `EditEntryModalContent`


