### PR TITLE
feat: full keyboard navigation in the popup

### DIFF
--- a/popup/App.tsx
+++ b/popup/App.tsx
@@ -56,6 +56,7 @@ import { useApp } from "./hooks/useApp";
 import { useCloudEntriesQuery } from "./hooks/useCloudEntriesQuery";
 import { useCloudFavoritedEntriesQuery } from "./hooks/useCloudFavoritedEntriesQuery";
 import { useCloudTaggedEntriesQuery } from "./hooks/useCloudTaggedEntriesQuery";
+import { SEARCH_INPUT_ID } from "./hooks/useEntryListNavigation";
 import { useSettingsQuery } from "./hooks/useSettingsQuery";
 import { useSubscriptionsQuery } from "./hooks/useSubscriptionsQuery";
 import { AllPage } from "./pages/AllPage";
@@ -291,6 +292,7 @@ export const App = () => {
         <Group align="center" position="apart">
           <TextInput
             ref={inputRef}
+            id={SEARCH_INPUT_ID}
             placeholder="Search items or tags"
             icon={<IconSearch size="1rem" />}
             size="xs"

--- a/popup/components/EntryList.tsx
+++ b/popup/components/EntryList.tsx
@@ -47,6 +47,9 @@ const EntryRowRenderer = ({
         entry={entry}
         selectedEntryIds={data.selectedEntryIds}
         isKeyboardSelected={index === data.selectedEntryIndex}
+        // The footer renders the list's closing border, so the last row drawing its own
+        // divider next to it would stack into a double border.
+        withDivider={index < data.entries.length - 1}
       />
     </Box>
   );
@@ -186,15 +189,7 @@ export const EntryList = ({ entries, noEntriesOverlay }: Props) => {
       </Box>
       {(entries.length > 0 || search.length > 0) && (
         <>
-          {/* Overlap the list by 1px so this border collapses into the bottom row's divider
-              instead of stacking with it when the list is scrolled to the bottom. */}
-          <Divider
-            sx={(theme) => ({
-              borderColor: defaultBorderColor(theme),
-              marginTop: -1,
-              position: "relative",
-            })}
-          />
+          <Divider sx={(theme) => ({ borderColor: defaultBorderColor(theme) })} />
           <Group align="center" spacing="md" noWrap px="sm" py={rem(4)}>
             {entries.length > 0 && (
               <>

--- a/popup/components/EntryList.tsx
+++ b/popup/components/EntryList.tsx
@@ -47,9 +47,6 @@ const EntryRowRenderer = ({
         entry={entry}
         selectedEntryIds={data.selectedEntryIds}
         isKeyboardSelected={index === data.selectedEntryIndex}
-        // The footer renders the list's closing border, so the last row drawing its own
-        // divider next to it would stack into a double border.
-        withDivider={index < data.entries.length - 1}
       />
     </Box>
   );
@@ -190,7 +187,9 @@ export const EntryList = ({ entries, noEntriesOverlay }: Props) => {
       {(entries.length > 0 || search.length > 0) && (
         <>
           <Divider sx={(theme) => ({ borderColor: defaultBorderColor(theme) })} />
-          <Group align="center" spacing="md" noWrap px="sm" py={rem(4)}>
+          {/* The extra padding offsets the list viewport so its overflow cut lands mid-row
+              instead of on a row divider, which would stack against the divider above. */}
+          <Group align="center" spacing="md" noWrap px="sm" py={rem(8)}>
             {entries.length > 0 && (
               <>
                 <KeyboardHint keys={["↑", "↓"]} label="Navigate" />

--- a/popup/components/EntryList.tsx
+++ b/popup/components/EntryList.tsx
@@ -186,7 +186,15 @@ export const EntryList = ({ entries, noEntriesOverlay }: Props) => {
       </Box>
       {(entries.length > 0 || search.length > 0) && (
         <>
-          <Divider sx={(theme) => ({ borderColor: defaultBorderColor(theme) })} />
+          {/* Overlap the list by 1px so this border collapses into the bottom row's divider
+              instead of stacking with it when the list is scrolled to the bottom. */}
+          <Divider
+            sx={(theme) => ({
+              borderColor: defaultBorderColor(theme),
+              marginTop: -1,
+              position: "relative",
+            })}
+          />
           <Group align="center" spacing="md" noWrap px="sm" py={rem(4)}>
             {entries.length > 0 && (
               <>

--- a/popup/components/EntryList.tsx
+++ b/popup/components/EntryList.tsx
@@ -1,12 +1,15 @@
-import { Box, Checkbox, Divider, Group, Stack, Text, Title, Tooltip } from "@mantine/core";
+import { Box, Checkbox, Divider, Group, rem, Stack, Text, Title, Tooltip } from "@mantine/core";
 import { modals } from "@mantine/modals";
 import { IconFold, IconStar, IconTrash } from "@tabler/icons-react";
+import { useAtomValue } from "jotai";
 import { useEffect, useMemo, type CSSProperties, type ReactNode } from "react";
 import AutoSizer from "react-virtualized-auto-sizer";
 import { FixedSizeList } from "react-window";
 
 import { useFavoriteEntryIds } from "~popup/contexts/FavoriteEntryIdsContext";
+import { useEntryListNavigation } from "~popup/hooks/useEntryListNavigation";
 import { useSet } from "~popup/hooks/useSet";
+import { searchAtom } from "~popup/states/atoms";
 import { handleMutation } from "~popup/utils/mutation";
 import { addFavoriteEntryIds, deleteFavoriteEntryIds } from "~storage/favoriteEntryIds";
 import type { Entry } from "~types/entry";
@@ -15,6 +18,7 @@ import { defaultBorderColor } from "~utils/sx";
 
 import { CommonActionIcon } from "./CommonActionIcon";
 import { EntryRow } from "./EntryRow";
+import { KeyboardHint } from "./KeyboardHint";
 import { MergeModalContent } from "./modals/MergeModalContent";
 
 interface Props {
@@ -30,6 +34,7 @@ const EntryRowRenderer = ({
   data: {
     entries: Entry[];
     selectedEntryIds: Set<string>;
+    selectedEntryIndex: number;
   };
   index: number;
   style: CSSProperties;
@@ -38,13 +43,19 @@ const EntryRowRenderer = ({
 
   return (
     <Box style={style}>
-      <EntryRow entry={entry} selectedEntryIds={data.selectedEntryIds} />
+      <EntryRow
+        entry={entry}
+        selectedEntryIds={data.selectedEntryIds}
+        isKeyboardSelected={index === data.selectedEntryIndex}
+      />
     </Box>
   );
 };
 
 export const EntryList = ({ entries, noEntriesOverlay }: Props) => {
   const favoriteEntryIdsSet = useFavoriteEntryIds();
+  const search = useAtomValue(searchAtom);
+  const { listRef, selectedEntryIndex } = useEntryListNavigation(entries);
 
   const selectedEntryIds = useSet<string>();
   const entryIdsStringified = useMemo(() => JSON.stringify(entries.map(({ id }) => id)), [entries]);
@@ -160,9 +171,10 @@ export const EntryList = ({ entries, noEntriesOverlay }: Props) => {
           <AutoSizer>
             {({ height, width }) => (
               <FixedSizeList
+                ref={listRef}
                 height={height}
                 width={width}
-                itemData={{ entries, selectedEntryIds }}
+                itemData={{ entries, selectedEntryIds, selectedEntryIndex }}
                 itemCount={entries.length}
                 itemSize={33}
               >
@@ -172,6 +184,20 @@ export const EntryList = ({ entries, noEntriesOverlay }: Props) => {
           </AutoSizer>
         )}
       </Box>
+      {(entries.length > 0 || search.length > 0) && (
+        <>
+          <Divider sx={(theme) => ({ borderColor: defaultBorderColor(theme) })} />
+          <Group align="center" spacing="md" noWrap px="sm" py={rem(4)}>
+            {entries.length > 0 && (
+              <>
+                <KeyboardHint keys={["↑", "↓"]} label="Navigate" />
+                <KeyboardHint keys={["↵"]} label="Copy" />
+              </>
+            )}
+            {search.length > 0 && <KeyboardHint keys={["Esc"]} label="Clear search" />}
+          </Group>
+        </>
+      )}
     </Stack>
   );
 };

--- a/popup/components/EntryRow.tsx
+++ b/popup/components/EntryRow.tsx
@@ -31,10 +31,9 @@ interface Props {
   entry: Entry;
   selectedEntryIds: Set<string>;
   isKeyboardSelected: boolean;
-  withDivider: boolean;
 }
 
-export const EntryRow = ({ entry, selectedEntryIds, isKeyboardSelected, withDivider }: Props) => {
+export const EntryRow = ({ entry, selectedEntryIds, isKeyboardSelected }: Props) => {
   const theme = useMantineTheme();
   const now = useNow();
   const settings = useAtomValue(settingsAtom);
@@ -170,7 +169,7 @@ export const EntryRow = ({ entry, selectedEntryIds, isKeyboardSelected, withDivi
           <EntryDeleteAction entryId={entry.id} />
         </Group>
       </Group>
-      {withDivider && <Divider sx={(theme) => ({ borderColor: defaultBorderColor(theme) })} />}
+      <Divider sx={(theme) => ({ borderColor: defaultBorderColor(theme) })} />
     </Stack>
   );
 };

--- a/popup/components/EntryRow.tsx
+++ b/popup/components/EntryRow.tsx
@@ -1,9 +1,10 @@
 import { Badge, Checkbox, Divider, Group, rem, Stack, Text, useMantineTheme } from "@mantine/core";
 import { modals } from "@mantine/modals";
 import { IconEdit, IconKeyboard } from "@tabler/icons-react";
-import { useAtom, useAtomValue } from "jotai";
+import { useAtomValue } from "jotai";
 
 import { useEntryIdToTags } from "~popup/contexts/EntryIdToTagsContext";
+import { useCopyEntry } from "~popup/hooks/useCopyEntry";
 import { useNow } from "~popup/hooks/useNow";
 import {
   clipboardSnapshotAtom,
@@ -11,12 +12,9 @@ import {
   entryCommandsAtom,
   settingsAtom,
 } from "~popup/states/atoms";
-import { updateClipboardSnapshot } from "~storage/clipboardSnapshot";
 import type { Entry } from "~types/entry";
-import { StorageLocation } from "~types/storageLocation";
 import { badgeDateFormatter } from "~utils/date";
 import { getEntryTimestamp } from "~utils/entries";
-import { createEntry } from "~utils/storage";
 import { defaultBorderColor, lightOrDark } from "~utils/sx";
 
 import { EntryCloudAction } from "./cloud/EntryCloudAction";
@@ -32,16 +30,18 @@ import { TagSelect } from "./TagSelect";
 interface Props {
   entry: Entry;
   selectedEntryIds: Set<string>;
+  isKeyboardSelected: boolean;
 }
 
-export const EntryRow = ({ entry, selectedEntryIds }: Props) => {
+export const EntryRow = ({ entry, selectedEntryIds, isKeyboardSelected }: Props) => {
   const theme = useMantineTheme();
   const now = useNow();
   const settings = useAtomValue(settingsAtom);
   const entryIdToTags = useEntryIdToTags();
   const entryCommands = useAtomValue(entryCommandsAtom);
   const commands = useAtomValue(commandsAtom);
-  const [clipboardSnapshot, setClipboardSnapshot] = useAtom(clipboardSnapshotAtom);
+  const clipboardSnapshot = useAtomValue(clipboardSnapshotAtom);
+  const copyEntry = useCopyEntry();
 
   const commandName = entryCommands.find(
     (entryCommand) => entryCommand.entryId === entry.id,
@@ -55,6 +55,11 @@ export const EntryRow = ({ entry, selectedEntryIds }: Props) => {
       sx={(theme) => ({
         backgroundColor: selectedEntryIds.has(entry.id)
           ? lightOrDark(theme, theme.colors.indigo[0], theme.fn.darken(theme.colors.indigo[9], 0.5))
+          : isKeyboardSelected
+            ? lightOrDark(theme, theme.colors.gray[0], theme.colors.dark[5])
+            : undefined,
+        boxShadow: isKeyboardSelected
+          ? `inset ${rem(3)} 0 0 0 ${lightOrDark(theme, theme.colors.indigo[5], theme.colors.indigo[4])}`
           : undefined,
         cursor: "pointer",
         ":hover": {
@@ -67,17 +72,7 @@ export const EntryRow = ({ entry, selectedEntryIds }: Props) => {
             : lightOrDark(theme, theme.colors.gray[0], theme.colors.dark[5]),
         },
       })}
-      onClick={async () => {
-        // Optimistically update local state with arbitrary updatedAt.
-        setClipboardSnapshot({ content: entry.content, updatedAt: 0 });
-
-        await updateClipboardSnapshot(entry.content);
-        navigator.clipboard.writeText(entry.content);
-        await createEntry(
-          entry.content,
-          entry.id.length === 36 ? StorageLocation.Enum.Cloud : StorageLocation.Enum.Local,
-        );
-      }}
+      onClick={() => copyEntry(entry)}
     >
       <Group align="center" spacing={0} noWrap px="sm" h={32}>
         <Checkbox

--- a/popup/components/EntryRow.tsx
+++ b/popup/components/EntryRow.tsx
@@ -31,9 +31,10 @@ interface Props {
   entry: Entry;
   selectedEntryIds: Set<string>;
   isKeyboardSelected: boolean;
+  withDivider: boolean;
 }
 
-export const EntryRow = ({ entry, selectedEntryIds, isKeyboardSelected }: Props) => {
+export const EntryRow = ({ entry, selectedEntryIds, isKeyboardSelected, withDivider }: Props) => {
   const theme = useMantineTheme();
   const now = useNow();
   const settings = useAtomValue(settingsAtom);
@@ -169,7 +170,7 @@ export const EntryRow = ({ entry, selectedEntryIds, isKeyboardSelected }: Props)
           <EntryDeleteAction entryId={entry.id} />
         </Group>
       </Group>
-      <Divider sx={(theme) => ({ borderColor: defaultBorderColor(theme) })} />
+      {withDivider && <Divider sx={(theme) => ({ borderColor: defaultBorderColor(theme) })} />}
     </Stack>
   );
 };

--- a/popup/components/KeyboardHint.tsx
+++ b/popup/components/KeyboardHint.tsx
@@ -1,0 +1,29 @@
+import { Group, Kbd, rem, Text } from "@mantine/core";
+
+interface Props {
+  keys: string[];
+  label: string;
+}
+
+export const KeyboardHint = ({ keys, label }: Props) => {
+  return (
+    <Group align="center" spacing={rem(4)} noWrap sx={{ userSelect: "none" }}>
+      {keys.map((key) => (
+        <Kbd
+          key={key}
+          sx={(theme) => ({
+            fontSize: rem(10),
+            lineHeight: 1,
+            padding: `${rem(2)} ${rem(4)}`,
+            color: theme.colors.gray[6],
+          })}
+        >
+          {key}
+        </Kbd>
+      ))}
+      <Text fz="xs" color="dimmed">
+        {label}
+      </Text>
+    </Group>
+  );
+};

--- a/popup/hooks/useCopyEntry.ts
+++ b/popup/hooks/useCopyEntry.ts
@@ -1,0 +1,27 @@
+import { useSetAtom } from "jotai";
+import { useCallback } from "react";
+
+import { clipboardSnapshotAtom } from "~popup/states/atoms";
+import { updateClipboardSnapshot } from "~storage/clipboardSnapshot";
+import type { Entry } from "~types/entry";
+import { StorageLocation } from "~types/storageLocation";
+import { createEntry } from "~utils/storage";
+
+export const useCopyEntry = () => {
+  const setClipboardSnapshot = useSetAtom(clipboardSnapshotAtom);
+
+  return useCallback(
+    async (entry: Entry) => {
+      // Optimistically update local state with arbitrary updatedAt.
+      setClipboardSnapshot({ content: entry.content, updatedAt: 0 });
+
+      await updateClipboardSnapshot(entry.content);
+      navigator.clipboard.writeText(entry.content);
+      await createEntry(
+        entry.content,
+        entry.id.length === 36 ? StorageLocation.Enum.Cloud : StorageLocation.Enum.Local,
+      );
+    },
+    [setClipboardSnapshot],
+  );
+};

--- a/popup/hooks/useEntryListNavigation.ts
+++ b/popup/hooks/useEntryListNavigation.ts
@@ -1,0 +1,120 @@
+import { useModals } from "@mantine/modals";
+import { useAtom } from "jotai";
+import { useEffect, useMemo, useRef, useState } from "react";
+import type { FixedSizeList } from "react-window";
+
+import { searchAtom } from "~popup/states/atoms";
+import type { Entry } from "~types/entry";
+
+import { useCopyEntry } from "./useCopyEntry";
+
+// The navigation keydown listener ignores keystrokes from text entry targets so it doesn't
+// hijack other inputs, with the search input as the one exception so entries can be navigated
+// and copied without ever leaving it.
+export const SEARCH_INPUT_ID = "entry-search-input";
+
+const isTextEntryTarget = (target: HTMLElement) =>
+  target.isContentEditable ||
+  target.tagName === "TEXTAREA" ||
+  target.tagName === "SELECT" ||
+  (target.tagName === "INPUT" &&
+    !["checkbox", "radio"].includes((target as HTMLInputElement).type));
+
+export const useEntryListNavigation = (entries: Entry[]) => {
+  const modals = useModals();
+  const [search, setSearch] = useAtom(searchAtom);
+  const copyEntry = useCopyEntry();
+
+  const listRef = useRef<FixedSizeList>(null);
+  const [selectedEntryId, setSelectedEntryId] = useState<string>();
+
+  // The selection defaults to the most relevant entry (the top one) and follows the selected
+  // entry through reorders. If the selected entry disappears the selection falls back to the
+  // top instead of jumping to an arbitrary neighbor.
+  const selectedEntryIndex = useMemo(() => {
+    if (selectedEntryId === undefined) {
+      return 0;
+    }
+
+    return Math.max(
+      entries.findIndex((entry) => entry.id === selectedEntryId),
+      0,
+    );
+  }, [entries, selectedEntryId]);
+
+  // Reset the selection to the top whenever the query changes so the best match is always one
+  // enter away.
+  useEffect(() => {
+    setSelectedEntryId(undefined);
+    listRef.current?.scrollToItem(0);
+  }, [search]);
+
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      // Let the IME consume keystrokes while composing.
+      if (e.isComposing) {
+        return;
+      }
+
+      // Modals and dropdowns (tag selects, menus) own the keyboard while open.
+      if (
+        modals.modals.length > 0 ||
+        document.querySelector(".mantine-Popover-dropdown, .mantine-Menu-dropdown") !== null
+      ) {
+        return;
+      }
+
+      const target = e.target instanceof HTMLElement ? e.target : null;
+
+      if (target !== null && target.id !== SEARCH_INPUT_ID && isTextEntryTarget(target)) {
+        return;
+      }
+
+      if (e.key === "ArrowDown" || e.key === "ArrowUp") {
+        if (entries.length === 0) {
+          return;
+        }
+
+        e.preventDefault();
+
+        const delta = e.key === "ArrowDown" ? 1 : -1;
+        const index = (selectedEntryIndex + delta + entries.length) % entries.length;
+        const entry = entries[index];
+
+        if (entry !== undefined) {
+          setSelectedEntryId(entry.id);
+          listRef.current?.scrollToItem(index);
+        }
+
+        return;
+      }
+
+      if (e.key === "Enter") {
+        // Buttons and links act on enter themselves.
+        if (target?.closest("button, a") != null) {
+          return;
+        }
+
+        const entry = entries[selectedEntryIndex];
+
+        if (entry !== undefined) {
+          e.preventDefault();
+          copyEntry(entry);
+        }
+
+        return;
+      }
+
+      if (e.key === "Escape" && search.length > 0) {
+        e.preventDefault();
+        e.stopPropagation();
+        setSearch("");
+      }
+    };
+
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [entries, selectedEntryIndex, search, modals.modals.length, copyEntry, setSearch]);
+
+  return { listRef, selectedEntryIndex };
+};


### PR DESCRIPTION
## What

Command palette style keyboard navigation for all three entry lists (All / Favorites / Cloud), across all three surfaces (toolbar popup, side panel, floating window):

- **↑ / ↓** — move a highlighted selection through the visible entries (wraps at the ends, auto-scrolls the virtualized list just enough to keep the selection in view)
- **↵** — copy the selected entry, with the existing optimistic "Copied" badge as instant feedback
- **Esc** — clear the search query (only intercepted while a query is active, so the default popup-close behavior is untouched otherwise)

The flow this unlocks: `Alt+Shift+V` → type a few characters → `↵`. No mouse.

## UX details

- The **top result is always pre-selected**, so the best match is one Enter away the moment you stop typing — same behavior as Spotlight/Raycast.
- The selection is rendered as a **3px indigo accent bar** (inset box-shadow, so row content never shifts) plus the hover background tone. It stays visually distinct from checkbox multi-selection (indigo fill) and composes with it.
- The selection is **id-based**: it follows the selected entry through list reorders (e.g. after a copy bumps an item to the top under "Date Last Copied" sort) instead of jumping to an arbitrary neighbor. It resets to the top result whenever the query changes.
- A slim **footer hint bar** advertises the shortcuts with `Kbd` chips, contextually: `Esc Clear search` only appears while a query is active, and nav hints only render when there are entries.
- The search input keeps focus the entire time — arrows/enter are handled at the window level, with the search input whitelisted as a navigation source.

## Correctness guards

The keydown listener defers to every other keyboard consumer in the popup:

- **Open modals** (edit, shortcuts, merge, settings…) via the `useModals()` context — navigation goes inert while any modal is open.
- **Open popovers/menus** (tag select, profile menu) via their Mantine dropdown selectors, since `TagSelect`/`Menu` own arrows + enter while open.
- **Other text-entry targets** (inputs, textareas, selects, contenteditable) are ignored so nothing hijacks typing; checkboxes/radios stay navigable.
- **Buttons/links** handle Enter themselves — no double-actions after clicking a row action icon.
- **IME composition** (`e.isComposing`) keystrokes are skipped, so confirming a CJK composition with Enter never triggers a copy.

## Refactor

The row click handler in `EntryRow` is extracted into a `useCopyEntry` hook so clicking a row and pressing Enter share one code path — no duplicated copy/snapshot logic.

## Deliberately out of scope

- `Cmd/Ctrl+1–9` quick-copy of the nth result: browsers reserve modifier+digit for tab switching on at least one platform each (Chrome Win/Linux `Ctrl+digit`, Firefox Win/Linux `Alt+digit`, macOS `Cmd+digit`), so this needs cross-platform validation before picking a binding.
- One caveat to validate manually: in the toolbar popup, some Chrome versions may close the popup on Esc before `preventDefault` lands. If so, the feature degrades to clear-search+close there, and works fully in the side panel and floating window.

## Validation

- `pnpm lint` ✅ `prettier --check` ✅ `pnpm build` (Chrome MV3) ✅
- `tsc --noEmit` clean for all touched files (one pre-existing, unrelated error in `utils/actionBadge.ts`: `Intl.NumberFormatOptions.roundingMode` vs the repo's TS 5.3 lib)
- No new dependencies, no storage/schema changes, no new permissions, Chrome-109-safe (no `toSorted`/`toReversed`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)