### PR TITLE
fix: reduce keyboard hint footer padding

### DIFF
--- a/popup/components/EntryList.tsx
+++ b/popup/components/EntryList.tsx
@@ -189,7 +189,7 @@ export const EntryList = ({ entries, noEntriesOverlay }: Props) => {
           <Divider sx={(theme) => ({ borderColor: defaultBorderColor(theme) })} />
           {/* The extra padding offsets the list viewport so its overflow cut lands mid-row
               instead of on a row divider, which would stack against the divider above. */}
-          <Group align="center" spacing="md" noWrap px="sm" py={rem(8)}>
+          <Group align="center" spacing="md" noWrap px="sm" py={rem(6)}>
             {entries.length > 0 && (
               <>
                 <KeyboardHint keys={["↑", "↓"]} label="Navigate" />


### PR DESCRIPTION
Fast follow to #122: drops the shortcut footer's vertical padding from `rem(8)` to `rem(6)`. The extra height shipped to keep the popup's list-viewport cut from landing exactly on a row divider (which stacked it against the footer's top border into a 2px line), but 8px read too tall — 6px still offsets the cut into row content while keeping the bar slim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)