### PR TITLE
feat: expand i18n language coverage and translatable strings

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+DEEPL_API_KEY=""

--- a/locales/ar/messages.json
+++ b/locales/ar/messages.json
@@ -1,8 +1,15 @@
 {
   "commonChangelog": { "message": "سجل التغييرات" },
   "commonSupportDevelopment": { "message": "دعم التطوير" },
-  "commonHelpAndFeedback": { "message": "المساعدة والملاحظات" },
+  "commonHelpAndFeedback": { "message": "المساعدة والتعليقات" },
   "commonFloatingMode": { "message": "الوضع العائم" },
+  "commonStorageUsage": { "message": "استخدام التخزين" },
   "commonSettings": { "message": "الإعدادات" },
-  "commonProfile": { "message": "الملف الشخصي" }
+  "commonProfile": { "message": "الملف الشخصي" },
+  "commonManageSubscription": { "message": "إدارة الاشتراك" },
+  "commonSignOut": { "message": "تسجيل الخروج" },
+  "commonOpenWebApp": { "message": "فتح تطبيق الويب" },
+  "commonAll": { "message": "الكل" },
+  "commonFavorites": { "message": "المفضلة" },
+  "commonCloud": { "message": "السحابة" }
 }

--- a/locales/bg/messages.json
+++ b/locales/bg/messages.json
@@ -1,8 +1,15 @@
 {
   "commonChangelog": { "message": "Списък с промените" },
-  "commonSupportDevelopment": { "message": "Разработване на поддръжка" },
+  "commonSupportDevelopment": { "message": "Подкрепете разработката" },
   "commonHelpAndFeedback": { "message": "Помощ и обратна връзка" },
   "commonFloatingMode": { "message": "Плаващ режим" },
+  "commonStorageUsage": { "message": "Използване на памет" },
   "commonSettings": { "message": "Настройки" },
-  "commonProfile": { "message": "Профил" }
+  "commonProfile": { "message": "Профил" },
+  "commonManageSubscription": { "message": "Управление на абонамента" },
+  "commonSignOut": { "message": "Изход" },
+  "commonOpenWebApp": { "message": "Отвори уеб приложение" },
+  "commonAll": { "message": "Всички" },
+  "commonFavorites": { "message": "Любими" },
+  "commonCloud": { "message": "Облак" }
 }

--- a/locales/bn/messages.json
+++ b/locales/bn/messages.json
@@ -1,0 +1,15 @@
+{
+  "commonChangelog": { "message": "পরিবর্তনলগ" },
+  "commonSupportDevelopment": { "message": "উন্নয়ন সমর্থন করুন" },
+  "commonHelpAndFeedback": { "message": "সহায়তা ও প্রতিক্রিয়া" },
+  "commonFloatingMode": { "message": "ফ্লোটিং মোড" },
+  "commonStorageUsage": { "message": "স্টোরেজ ব্যবহার" },
+  "commonSettings": { "message": "সেটিংস" },
+  "commonProfile": { "message": "প্রোফাইল" },
+  "commonManageSubscription": { "message": "সাবস্ক্রিপশন পরিচালনা করুন" },
+  "commonSignOut": { "message": "সাইন আউট" },
+  "commonOpenWebApp": { "message": "ওয়েব অ্যাপ খুলুন" },
+  "commonAll": { "message": "সমস্ত" },
+  "commonFavorites": { "message": "প্রিয়" },
+  "commonCloud": { "message": "ক্লাউড" }
+}

--- a/locales/ca/messages.json
+++ b/locales/ca/messages.json
@@ -1,0 +1,15 @@
+{
+  "commonChangelog": { "message": "Diari de canvis" },
+  "commonSupportDevelopment": { "message": "Dona suport al desenvolupament" },
+  "commonHelpAndFeedback": { "message": "Ajuda i comentaris" },
+  "commonFloatingMode": { "message": "Mode flotant" },
+  "commonStorageUsage": { "message": "Ús de l'emmagatzematge" },
+  "commonSettings": { "message": "Configuració" },
+  "commonProfile": { "message": "Perfil" },
+  "commonManageSubscription": { "message": "Gestiona la subscripció" },
+  "commonSignOut": { "message": "Tanca la sessió" },
+  "commonOpenWebApp": { "message": "Obre l'aplicació web" },
+  "commonAll": { "message": "Tots" },
+  "commonFavorites": { "message": "Favorits" },
+  "commonCloud": { "message": "Núvol" }
+}

--- a/locales/cs/messages.json
+++ b/locales/cs/messages.json
@@ -1,8 +1,15 @@
 {
   "commonChangelog": { "message": "Seznam změn" },
-  "commonSupportDevelopment": { "message": "Vývoj podpory" },
+  "commonSupportDevelopment": { "message": "Podpora vývoje" },
   "commonHelpAndFeedback": { "message": "Nápověda a zpětná vazba" },
   "commonFloatingMode": { "message": "Plovoucí režim" },
+  "commonStorageUsage": { "message": "Využití úložiště" },
   "commonSettings": { "message": "Nastavení" },
-  "commonProfile": { "message": "Profil" }
+  "commonProfile": { "message": "Profil" },
+  "commonManageSubscription": { "message": "Spravovat předplatné" },
+  "commonSignOut": { "message": "Odhlásit se" },
+  "commonOpenWebApp": { "message": "Otevřít webovou aplikaci" },
+  "commonAll": { "message": "Vše" },
+  "commonFavorites": { "message": "Oblíbené" },
+  "commonCloud": { "message": "Cloud" }
 }

--- a/locales/da/messages.json
+++ b/locales/da/messages.json
@@ -1,8 +1,15 @@
 {
-  "commonChangelog": { "message": "Changelog" },
-  "commonSupportDevelopment": { "message": "Støtte til udvikling" },
+  "commonChangelog": { "message": "Ændringslog" },
+  "commonSupportDevelopment": { "message": "Støt udviklingen" },
   "commonHelpAndFeedback": { "message": "Hjælp og feedback" },
   "commonFloatingMode": { "message": "Flydende tilstand" },
+  "commonStorageUsage": { "message": "Lagerpladsforbrug" },
   "commonSettings": { "message": "Indstillinger" },
-  "commonProfile": { "message": "Profil" }
+  "commonProfile": { "message": "Profil" },
+  "commonManageSubscription": { "message": "Administrer abonnement" },
+  "commonSignOut": { "message": "Log ud" },
+  "commonOpenWebApp": { "message": "Åbn webapp" },
+  "commonAll": { "message": "Alle" },
+  "commonFavorites": { "message": "Favoritter" },
+  "commonCloud": { "message": "Cloud" }
 }

--- a/locales/de/messages.json
+++ b/locales/de/messages.json
@@ -1,8 +1,15 @@
 {
-  "commonChangelog": { "message": "Changelog" },
-  "commonSupportDevelopment": { "message": "Entwicklung unterstützen" },
+  "commonChangelog": { "message": "Änderungsprotokoll" },
+  "commonSupportDevelopment": { "message": "Entwicklungsunterstützung" },
   "commonHelpAndFeedback": { "message": "Hilfe & Feedback" },
-  "commonFloatingMode": { "message": "Schwebender Modus" },
+  "commonFloatingMode": { "message": "Floating-Modus" },
+  "commonStorageUsage": { "message": "Speichernutzung" },
   "commonSettings": { "message": "Einstellungen" },
-  "commonProfile": { "message": "Profil" }
+  "commonProfile": { "message": "Profil" },
+  "commonManageSubscription": { "message": "Abonnement verwalten" },
+  "commonSignOut": { "message": "Abmelden" },
+  "commonOpenWebApp": { "message": "Web-App öffnen" },
+  "commonAll": { "message": "Alle" },
+  "commonFavorites": { "message": "Favoriten" },
+  "commonCloud": { "message": "Cloud" }
 }

--- a/locales/el/messages.json
+++ b/locales/el/messages.json
@@ -1,8 +1,15 @@
 {
-  "commonChangelog": { "message": "Changelog" },
-  "commonSupportDevelopment": { "message": "Ανάπτυξη υποστήριξης" },
-  "commonHelpAndFeedback": { "message": "Βοήθεια και σχόλια" },
-  "commonFloatingMode": { "message": "Κυμαινόμενη λειτουργία" },
+  "commonChangelog": { "message": "Αρχείο αλλαγών" },
+  "commonSupportDevelopment": { "message": "Υποστήριξη ανάπτυξης" },
+  "commonHelpAndFeedback": { "message": "Βοήθεια & Σχόλια" },
+  "commonFloatingMode": { "message": "Λειτουργία πλωτού παραθύρου" },
+  "commonStorageUsage": { "message": "Χρήση χώρου αποθήκευσης" },
   "commonSettings": { "message": "Ρυθμίσεις" },
-  "commonProfile": { "message": "Προφίλ" }
+  "commonProfile": { "message": "Προφίλ" },
+  "commonManageSubscription": { "message": "Διαχείριση συνδρομής" },
+  "commonSignOut": { "message": "Αποσύνδεση" },
+  "commonOpenWebApp": { "message": "Άνοιγμα εφαρμογής ιστού" },
+  "commonAll": { "message": "Όλα" },
+  "commonFavorites": { "message": "Αγαπημένα" },
+  "commonCloud": { "message": "Cloud" }
 }

--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -15,6 +15,10 @@
     "message": "Floating Mode",
     "description": "Title for tooltip for button that opens the Chrome extension in a separate window."
   },
+  "commonStorageUsage": {
+    "message": "Storage Usage",
+    "description": "Title for tooltip and heading for the view that shows how much storage the clipboard history is using."
+  },
   "commonSettings": {
     "message": "Settings",
     "description": "Title for tooltip for button that opens the Chrome extension's settings."
@@ -22,5 +26,29 @@
   "commonProfile": {
     "message": "Profile",
     "description": "Title for tooltip for button that opens a menu with various actions relating to the user's profile."
+  },
+  "commonManageSubscription": {
+    "message": "Manage Subscription",
+    "description": "Label for the menu item that opens the page where the user manages their paid subscription."
+  },
+  "commonSignOut": {
+    "message": "Sign Out",
+    "description": "Label for the menu item that signs the user out of their account."
+  },
+  "commonOpenWebApp": {
+    "message": "Open Web App",
+    "description": "Label for the menu item that opens the web version of the application in a new browser tab."
+  },
+  "commonAll": {
+    "message": "All",
+    "description": "Label for the tab that lists every clipboard history item."
+  },
+  "commonFavorites": {
+    "message": "Favorites",
+    "description": "Label for the tab that lists clipboard history items the user has marked as favorite."
+  },
+  "commonCloud": {
+    "message": "Cloud",
+    "description": "Label for the tab that lists clipboard history items synced to the cloud."
   }
 }

--- a/locales/en_AU/messages.json
+++ b/locales/en_AU/messages.json
@@ -3,6 +3,13 @@
   "commonSupportDevelopment": { "message": "Support Development" },
   "commonHelpAndFeedback": { "message": "Help & Feedback" },
   "commonFloatingMode": { "message": "Floating Mode" },
+  "commonStorageUsage": { "message": "Storage Usage" },
   "commonSettings": { "message": "Settings" },
-  "commonProfile": { "message": "Profile" }
+  "commonProfile": { "message": "Profile" },
+  "commonManageSubscription": { "message": "Manage Subscription" },
+  "commonSignOut": { "message": "Sign Out" },
+  "commonOpenWebApp": { "message": "Open Web App" },
+  "commonAll": { "message": "All" },
+  "commonFavorites": { "message": "Favorites" },
+  "commonCloud": { "message": "Cloud" }
 }

--- a/locales/en_GB/messages.json
+++ b/locales/en_GB/messages.json
@@ -3,6 +3,13 @@
   "commonSupportDevelopment": { "message": "Support Development" },
   "commonHelpAndFeedback": { "message": "Help & Feedback" },
   "commonFloatingMode": { "message": "Floating Mode" },
+  "commonStorageUsage": { "message": "Storage Usage" },
   "commonSettings": { "message": "Settings" },
-  "commonProfile": { "message": "Profile" }
+  "commonProfile": { "message": "Profile" },
+  "commonManageSubscription": { "message": "Manage Subscription" },
+  "commonSignOut": { "message": "Sign Out" },
+  "commonOpenWebApp": { "message": "Open Web App" },
+  "commonAll": { "message": "All" },
+  "commonFavorites": { "message": "Favorites" },
+  "commonCloud": { "message": "Cloud" }
 }

--- a/locales/en_US/messages.json
+++ b/locales/en_US/messages.json
@@ -3,6 +3,13 @@
   "commonSupportDevelopment": { "message": "Support Development" },
   "commonHelpAndFeedback": { "message": "Help & Feedback" },
   "commonFloatingMode": { "message": "Floating Mode" },
+  "commonStorageUsage": { "message": "Storage Usage" },
   "commonSettings": { "message": "Settings" },
-  "commonProfile": { "message": "Profile" }
+  "commonProfile": { "message": "Profile" },
+  "commonManageSubscription": { "message": "Manage Subscription" },
+  "commonSignOut": { "message": "Sign Out" },
+  "commonOpenWebApp": { "message": "Open Web App" },
+  "commonAll": { "message": "All" },
+  "commonFavorites": { "message": "Favorites" },
+  "commonCloud": { "message": "Cloud" }
 }

--- a/locales/es/messages.json
+++ b/locales/es/messages.json
@@ -3,6 +3,13 @@
   "commonSupportDevelopment": { "message": "Desarrollo de soporte" },
   "commonHelpAndFeedback": { "message": "Ayuda y comentarios" },
   "commonFloatingMode": { "message": "Modo flotante" },
+  "commonStorageUsage": { "message": "Uso del almacenamiento" },
   "commonSettings": { "message": "Configuración" },
-  "commonProfile": { "message": "Perfil" }
+  "commonProfile": { "message": "Perfil" },
+  "commonManageSubscription": { "message": "Gestionar suscripción" },
+  "commonSignOut": { "message": "Cerrar sesión" },
+  "commonOpenWebApp": { "message": "Abrir aplicación web" },
+  "commonAll": { "message": "Todo" },
+  "commonFavorites": { "message": "Favoritos" },
+  "commonCloud": { "message": "Nube" }
 }

--- a/locales/es_419/messages.json
+++ b/locales/es_419/messages.json
@@ -3,6 +3,13 @@
   "commonSupportDevelopment": { "message": "Desarrollo de soporte" },
   "commonHelpAndFeedback": { "message": "Ayuda y comentarios" },
   "commonFloatingMode": { "message": "Modo flotante" },
+  "commonStorageUsage": { "message": "Uso de almacenamiento" },
   "commonSettings": { "message": "Configuración" },
-  "commonProfile": { "message": "Perfil" }
+  "commonProfile": { "message": "Perfil" },
+  "commonManageSubscription": { "message": "Administrar suscripción" },
+  "commonSignOut": { "message": "Cerrar sesión" },
+  "commonOpenWebApp": { "message": "Abrir aplicación web" },
+  "commonAll": { "message": "Todo" },
+  "commonFavorites": { "message": "Favoritos" },
+  "commonCloud": { "message": "Nube" }
 }

--- a/locales/et/messages.json
+++ b/locales/et/messages.json
@@ -1,8 +1,15 @@
 {
-  "commonChangelog": { "message": "Changelog" },
-  "commonSupportDevelopment": { "message": "Toetuse arendus" },
+  "commonChangelog": { "message": "Muudatuste ajalugu" },
+  "commonSupportDevelopment": { "message": "Toetage arendustööd" },
   "commonHelpAndFeedback": { "message": "Abi ja tagasiside" },
   "commonFloatingMode": { "message": "Ujuv režiim" },
+  "commonStorageUsage": { "message": "Salvestusruumi kasutamine" },
   "commonSettings": { "message": "Seaded" },
-  "commonProfile": { "message": "Profiil" }
+  "commonProfile": { "message": "Profiil" },
+  "commonManageSubscription": { "message": "Haldus" },
+  "commonSignOut": { "message": "Välja logida" },
+  "commonOpenWebApp": { "message": "Ava veebirakendus" },
+  "commonAll": { "message": "Kõik" },
+  "commonFavorites": { "message": "Lemmikud" },
+  "commonCloud": { "message": "Pilv" }
 }

--- a/locales/fa/messages.json
+++ b/locales/fa/messages.json
@@ -1,0 +1,15 @@
+{
+  "commonChangelog": { "message": "تاریخچه تغییرات" },
+  "commonSupportDevelopment": { "message": "حمایت از توسعه" },
+  "commonHelpAndFeedback": { "message": "کمک و بازخورد" },
+  "commonFloatingMode": { "message": "حالت شناور" },
+  "commonStorageUsage": { "message": "مقدار مصرف حافظه ذخیره‌سازی" },
+  "commonSettings": { "message": "تنظیمات" },
+  "commonProfile": { "message": "پروفایل" },
+  "commonManageSubscription": { "message": "مدیریت اشتراک" },
+  "commonSignOut": { "message": "خروج" },
+  "commonOpenWebApp": { "message": "راه‌اندازی برنامهٔ وب" },
+  "commonAll": { "message": "همه" },
+  "commonFavorites": { "message": "علاقه‌مندی‌ها" },
+  "commonCloud": { "message": "ابری" }
+}

--- a/locales/fi/messages.json
+++ b/locales/fi/messages.json
@@ -1,8 +1,15 @@
 {
-  "commonChangelog": { "message": "Changelog" },
-  "commonSupportDevelopment": { "message": "Tukikehitys" },
+  "commonChangelog": { "message": "Muutosloki" },
+  "commonSupportDevelopment": { "message": "Kehitystuki" },
   "commonHelpAndFeedback": { "message": "Ohje ja palaute" },
   "commonFloatingMode": { "message": "Kelluva tila" },
+  "commonStorageUsage": { "message": "Tallennustilan käyttö" },
   "commonSettings": { "message": "Asetukset" },
-  "commonProfile": { "message": "Profiili" }
+  "commonProfile": { "message": "Profiili" },
+  "commonManageSubscription": { "message": "Hallitse tilausta" },
+  "commonSignOut": { "message": "Kirjaudu ulos" },
+  "commonOpenWebApp": { "message": "Avaa verkkosovellus" },
+  "commonAll": { "message": "Kaikki" },
+  "commonFavorites": { "message": "Suosikit" },
+  "commonCloud": { "message": "Pilvi" }
 }

--- a/locales/fil/messages.json
+++ b/locales/fil/messages.json
@@ -1,0 +1,15 @@
+{
+  "commonChangelog": { "message": "Tala ng mga pagbabago" },
+  "commonSupportDevelopment": { "message": "Suportahan ang Pag-unlad" },
+  "commonHelpAndFeedback": { "message": "Tulong at Mungkahi" },
+  "commonFloatingMode": { "message": "Floating Mode" },
+  "commonStorageUsage": { "message": "Paggamit ng Imbakan" },
+  "commonSettings": { "message": "Mga setting" },
+  "commonProfile": { "message": "Profil" },
+  "commonManageSubscription": { "message": "Pamamahala ng Subscription" },
+  "commonSignOut": { "message": "Mag-sign out" },
+  "commonOpenWebApp": { "message": "Buksan ang Web App" },
+  "commonAll": { "message": "Lahat" },
+  "commonFavorites": { "message": "Mga Paborito" },
+  "commonCloud": { "message": "Ulap" }
+}

--- a/locales/fr/messages.json
+++ b/locales/fr/messages.json
@@ -1,8 +1,15 @@
 {
   "commonChangelog": { "message": "Journal des modifications" },
-  "commonSupportDevelopment": { "message": "Développement du support" },
+  "commonSupportDevelopment": { "message": "Soutien au développement" },
   "commonHelpAndFeedback": { "message": "Aide et commentaires" },
   "commonFloatingMode": { "message": "Mode flottant" },
+  "commonStorageUsage": { "message": "Utilisation de l'espace de stockage" },
   "commonSettings": { "message": "Paramètres" },
-  "commonProfile": { "message": "Profil" }
+  "commonProfile": { "message": "Profil" },
+  "commonManageSubscription": { "message": "Gérer l'abonnement" },
+  "commonSignOut": { "message": "Se déconnecter" },
+  "commonOpenWebApp": { "message": "Ouvrir l'application Web" },
+  "commonAll": { "message": "Tout" },
+  "commonFavorites": { "message": "Favoris" },
+  "commonCloud": { "message": "Cloud" }
 }

--- a/locales/gu/messages.json
+++ b/locales/gu/messages.json
@@ -1,0 +1,15 @@
+{
+  "commonChangelog": { "message": "બદલાવ લૉગ" },
+  "commonSupportDevelopment": { "message": "વિકાસને ટેકો આપો" },
+  "commonHelpAndFeedback": { "message": "મદદ અને પ્રતિસાદ" },
+  "commonFloatingMode": { "message": "ફ્લોટિંગ મોડ" },
+  "commonStorageUsage": { "message": "સંગ્રહ ઉપયોગ" },
+  "commonSettings": { "message": "સેટિંગ્સ" },
+  "commonProfile": { "message": "પ્રોફાઇલ" },
+  "commonManageSubscription": { "message": "સબ્સ્ક્રિપ્શન સંચાલિત કરો" },
+  "commonSignOut": { "message": "સાઇન આઉટ" },
+  "commonOpenWebApp": { "message": "વેબ એપ ખોલો" },
+  "commonAll": { "message": "બધા" },
+  "commonFavorites": { "message": "પસંદીદા" },
+  "commonCloud": { "message": "ક્લાઉડ" }
+}

--- a/locales/he/messages.json
+++ b/locales/he/messages.json
@@ -1,0 +1,15 @@
+{
+  "commonChangelog": { "message": "יומן השינויים" },
+  "commonSupportDevelopment": { "message": "תמיכה בפיתוח" },
+  "commonHelpAndFeedback": { "message": "עזרה ומשוב" },
+  "commonFloatingMode": { "message": "מצב צף" },
+  "commonStorageUsage": { "message": "שימוש באחסון" },
+  "commonSettings": { "message": "הגדרות" },
+  "commonProfile": { "message": "פרופיל" },
+  "commonManageSubscription": { "message": "נהל מנוי" },
+  "commonSignOut": { "message": "התנתק" },
+  "commonOpenWebApp": { "message": "פתח את אפליקציית האינטרנט" },
+  "commonAll": { "message": "הכל" },
+  "commonFavorites": { "message": "מועדפים" },
+  "commonCloud": { "message": "ענן" }
+}

--- a/locales/hi/messages.json
+++ b/locales/hi/messages.json
@@ -1,0 +1,15 @@
+{
+  "commonChangelog": { "message": "परिवर्तन-लॉग" },
+  "commonSupportDevelopment": { "message": "विकास का समर्थन करें" },
+  "commonHelpAndFeedback": { "message": "सहायता और प्रतिक्रिया" },
+  "commonFloatingMode": { "message": "फ़्लोटिंग मोड" },
+  "commonStorageUsage": { "message": "भंडारण उपयोग" },
+  "commonSettings": { "message": "सेटिंग्स" },
+  "commonProfile": { "message": "प्रोफ़ाइल" },
+  "commonManageSubscription": { "message": "सदस्यता प्रबंधित करें" },
+  "commonSignOut": { "message": "साइन आउट" },
+  "commonOpenWebApp": { "message": "वेब ऐप खोलें" },
+  "commonAll": { "message": "सभी" },
+  "commonFavorites": { "message": "पसंदीदा" },
+  "commonCloud": { "message": "क्लाउड" }
+}

--- a/locales/hr/messages.json
+++ b/locales/hr/messages.json
@@ -1,0 +1,15 @@
+{
+  "commonChangelog": { "message": "Zapisnik promjena" },
+  "commonSupportDevelopment": { "message": "Podržite razvoj" },
+  "commonHelpAndFeedback": { "message": "Pomoć i povratne informacije" },
+  "commonFloatingMode": { "message": "Plutajući način rada" },
+  "commonStorageUsage": { "message": "Upotreba pohrane" },
+  "commonSettings": { "message": "Postavke" },
+  "commonProfile": { "message": "Profil" },
+  "commonManageSubscription": { "message": "Upravljanje pretplatom" },
+  "commonSignOut": { "message": "Odjavi se" },
+  "commonOpenWebApp": { "message": "Otvori web aplikaciju" },
+  "commonAll": { "message": "Sve" },
+  "commonFavorites": { "message": "Favoriti" },
+  "commonCloud": { "message": "Oblačak" }
+}

--- a/locales/hu/messages.json
+++ b/locales/hu/messages.json
@@ -1,8 +1,15 @@
 {
-  "commonChangelog": { "message": "Changelog" },
-  "commonSupportDevelopment": { "message": "Támogatás fejlesztése" },
+  "commonChangelog": { "message": "Változásnapló" },
+  "commonSupportDevelopment": { "message": "Fejlesztés támogatása" },
   "commonHelpAndFeedback": { "message": "Súgó és visszajelzés" },
   "commonFloatingMode": { "message": "Lebegő mód" },
+  "commonStorageUsage": { "message": "Tárolóhely-használat" },
   "commonSettings": { "message": "Beállítások" },
-  "commonProfile": { "message": "Profil" }
+  "commonProfile": { "message": "Profil" },
+  "commonManageSubscription": { "message": "Előfizetés kezelése" },
+  "commonSignOut": { "message": "Kijelentkezés" },
+  "commonOpenWebApp": { "message": "Webalkalmazás megnyitása" },
+  "commonAll": { "message": "Minden" },
+  "commonFavorites": { "message": "Kedvencek" },
+  "commonCloud": { "message": "Felhő" }
 }

--- a/locales/id/messages.json
+++ b/locales/id/messages.json
@@ -1,8 +1,15 @@
 {
-  "commonChangelog": { "message": "Catatan perubahan" },
-  "commonSupportDevelopment": { "message": "Mendukung Pengembangan" },
+  "commonChangelog": { "message": "Catatan Perubahan" },
+  "commonSupportDevelopment": { "message": "Dukung Pengembangan" },
   "commonHelpAndFeedback": { "message": "Bantuan & Umpan Balik" },
   "commonFloatingMode": { "message": "Mode Mengambang" },
+  "commonStorageUsage": { "message": "Penggunaan Penyimpanan" },
   "commonSettings": { "message": "Pengaturan" },
-  "commonProfile": { "message": "Profil" }
+  "commonProfile": { "message": "Profil" },
+  "commonManageSubscription": { "message": "Kelola Langganan" },
+  "commonSignOut": { "message": "Keluar" },
+  "commonOpenWebApp": { "message": "Buka Aplikasi Web" },
+  "commonAll": { "message": "Semua" },
+  "commonFavorites": { "message": "Favorit" },
+  "commonCloud": { "message": "Cloud" }
 }

--- a/locales/it/messages.json
+++ b/locales/it/messages.json
@@ -1,8 +1,15 @@
 {
-  "commonChangelog": { "message": "Changelog" },
-  "commonSupportDevelopment": { "message": "Sviluppo del supporto" },
+  "commonChangelog": { "message": "Registro delle modifiche" },
+  "commonSupportDevelopment": { "message": "Sostieni lo sviluppo" },
   "commonHelpAndFeedback": { "message": "Aiuto e feedback" },
   "commonFloatingMode": { "message": "Modalità fluttuante" },
+  "commonStorageUsage": { "message": "Utilizzo dello spazio di archiviazione" },
   "commonSettings": { "message": "Impostazioni" },
-  "commonProfile": { "message": "Profilo" }
+  "commonProfile": { "message": "Profilo" },
+  "commonManageSubscription": { "message": "Gestisci abbonamento" },
+  "commonSignOut": { "message": "Esci" },
+  "commonOpenWebApp": { "message": "Apri app web" },
+  "commonAll": { "message": "Tutto" },
+  "commonFavorites": { "message": "Preferiti" },
+  "commonCloud": { "message": "Cloud" }
 }

--- a/locales/ja/messages.json
+++ b/locales/ja/messages.json
@@ -1,8 +1,15 @@
 {
   "commonChangelog": { "message": "変更履歴" },
-  "commonSupportDevelopment": { "message": "サポート開発" },
-  "commonHelpAndFeedback": { "message": "ヘルプ＆フィードバック" },
+  "commonSupportDevelopment": { "message": "開発支援" },
+  "commonHelpAndFeedback": { "message": "ヘルプとフィードバック" },
   "commonFloatingMode": { "message": "フローティングモード" },
+  "commonStorageUsage": { "message": "ストレージ使用量" },
   "commonSettings": { "message": "設定" },
-  "commonProfile": { "message": "プロフィール" }
+  "commonProfile": { "message": "プロフィール" },
+  "commonManageSubscription": { "message": "サブスクリプションの管理" },
+  "commonSignOut": { "message": "サインアウト" },
+  "commonOpenWebApp": { "message": "Webアプリを開く" },
+  "commonAll": { "message": "すべて" },
+  "commonFavorites": { "message": "お気に入り" },
+  "commonCloud": { "message": "クラウド" }
 }

--- a/locales/ko/messages.json
+++ b/locales/ko/messages.json
@@ -1,8 +1,15 @@
 {
-  "commonChangelog": { "message": "변경 로그" },
+  "commonChangelog": { "message": "변경 내역" },
   "commonSupportDevelopment": { "message": "개발 지원" },
   "commonHelpAndFeedback": { "message": "도움말 및 피드백" },
   "commonFloatingMode": { "message": "플로팅 모드" },
+  "commonStorageUsage": { "message": "저장 공간 사용량" },
   "commonSettings": { "message": "설정" },
-  "commonProfile": { "message": "프로필" }
+  "commonProfile": { "message": "프로필" },
+  "commonManageSubscription": { "message": "구독 관리" },
+  "commonSignOut": { "message": "로그아웃" },
+  "commonOpenWebApp": { "message": "웹 앱 열기" },
+  "commonAll": { "message": "전체" },
+  "commonFavorites": { "message": "즐겨찾기" },
+  "commonCloud": { "message": "클라우드" }
 }

--- a/locales/lt/messages.json
+++ b/locales/lt/messages.json
@@ -1,8 +1,15 @@
 {
-  "commonChangelog": { "message": "Pakeitimų žurnalas" },
-  "commonSupportDevelopment": { "message": "Paramos kūrimas" },
+  "commonChangelog": { "message": "Pakeitimų sąrašas" },
+  "commonSupportDevelopment": { "message": "Parama plėtrai" },
   "commonHelpAndFeedback": { "message": "Pagalba ir atsiliepimai" },
   "commonFloatingMode": { "message": "Plaukiojantis režimas" },
+  "commonStorageUsage": { "message": "Atminties naudojimas" },
   "commonSettings": { "message": "Nustatymai" },
-  "commonProfile": { "message": "Profilis" }
+  "commonProfile": { "message": "Profilis" },
+  "commonManageSubscription": { "message": "Prenumeratos valdymas" },
+  "commonSignOut": { "message": "Atsijungti" },
+  "commonOpenWebApp": { "message": "Atidaryti internetinę programą" },
+  "commonAll": { "message": "Visi" },
+  "commonFavorites": { "message": "Mėgstamiausi" },
+  "commonCloud": { "message": "Debesis" }
 }

--- a/locales/lv/messages.json
+++ b/locales/lv/messages.json
@@ -1,8 +1,15 @@
 {
   "commonChangelog": { "message": "Izmaiņu žurnāls" },
-  "commonSupportDevelopment": { "message": "Atbalsta izstrāde" },
+  "commonSupportDevelopment": { "message": "Atbalsts izstrādei" },
   "commonHelpAndFeedback": { "message": "Palīdzība un atsauksmes" },
   "commonFloatingMode": { "message": "Peldošais režīms" },
+  "commonStorageUsage": { "message": "Atmiņas izmantošana" },
   "commonSettings": { "message": "Iestatījumi" },
-  "commonProfile": { "message": "Profils" }
+  "commonProfile": { "message": "Profils" },
+  "commonManageSubscription": { "message": "Pārvaldīt abonementu" },
+  "commonSignOut": { "message": "Iziet" },
+  "commonOpenWebApp": { "message": "Atvērt tīmekļa lietotni" },
+  "commonAll": { "message": "Viss" },
+  "commonFavorites": { "message": "Izlase" },
+  "commonCloud": { "message": "Mākonis" }
 }

--- a/locales/ml/messages.json
+++ b/locales/ml/messages.json
@@ -1,0 +1,15 @@
+{
+  "commonChangelog": { "message": "മാറ്റങ്ങളുടെ പട്ടിക" },
+  "commonSupportDevelopment": { "message": "വികസനത്തെ പിന്തുണയ്ക്കുക" },
+  "commonHelpAndFeedback": { "message": "സഹായവും ഫീഡ്‌ബാക്കും" },
+  "commonFloatingMode": { "message": "ഫ്ലോട്ടിംഗ് മോഡ്" },
+  "commonStorageUsage": { "message": "സംഭരണ ഉപയോഗം" },
+  "commonSettings": { "message": "ക്രമീകരണങ്ങൾ" },
+  "commonProfile": { "message": "പ്രൊഫൈൽ" },
+  "commonManageSubscription": { "message": "സബ്സ്ക്രിപ്ഷൻ നിയന്ത്രിക്കുക" },
+  "commonSignOut": { "message": "സൈൻ ഔട്ട്" },
+  "commonOpenWebApp": { "message": "വെബ് ആപ്പ് തുറക്കുക" },
+  "commonAll": { "message": "എല്ലാം" },
+  "commonFavorites": { "message": "ഇഷ്ടപ്പെട്ടവ" },
+  "commonCloud": { "message": "ക്ലൗഡ്" }
+}

--- a/locales/mr/messages.json
+++ b/locales/mr/messages.json
@@ -1,0 +1,15 @@
+{
+  "commonChangelog": { "message": "बदल इतिहास" },
+  "commonSupportDevelopment": { "message": "विकास समर्थन" },
+  "commonHelpAndFeedback": { "message": "मदत आणि अभिप्राय" },
+  "commonFloatingMode": { "message": "फ्लोटिंग मोड" },
+  "commonStorageUsage": { "message": "साठवण वापर" },
+  "commonSettings": { "message": "सेटिंग्ज" },
+  "commonProfile": { "message": "प्रोफाइल" },
+  "commonManageSubscription": { "message": "सदस्यता व्यवस्थापित करा" },
+  "commonSignOut": { "message": "लॉगआउट करा" },
+  "commonOpenWebApp": { "message": "वेब अॅप उघडा" },
+  "commonAll": { "message": "सर्व" },
+  "commonFavorites": { "message": "पसंदीदा" },
+  "commonCloud": { "message": "क्लाउड" }
+}

--- a/locales/ms/messages.json
+++ b/locales/ms/messages.json
@@ -1,0 +1,15 @@
+{
+  "commonChangelog": { "message": "Logs perubahan" },
+  "commonSupportDevelopment": { "message": "Dukong Pembangunan" },
+  "commonHelpAndFeedback": { "message": "Bantuan & Maklum Balas" },
+  "commonFloatingMode": { "message": "Mod Terapung" },
+  "commonStorageUsage": { "message": "Penggunaan Penyimpanan" },
+  "commonSettings": { "message": "Tetapan" },
+  "commonProfile": { "message": "Profil" },
+  "commonManageSubscription": { "message": "Kelola Langganan" },
+  "commonSignOut": { "message": "Log Keluar" },
+  "commonOpenWebApp": { "message": "Buka Aplikasi Web" },
+  "commonAll": { "message": "Semua" },
+  "commonFavorites": { "message": "Kegemaran" },
+  "commonCloud": { "message": "Awan" }
+}

--- a/locales/nl/messages.json
+++ b/locales/nl/messages.json
@@ -1,8 +1,15 @@
 {
-  "commonChangelog": { "message": "Changelog" },
+  "commonChangelog": { "message": "Wijzigingslogboek" },
   "commonSupportDevelopment": { "message": "Ondersteuning Ontwikkeling" },
-  "commonHelpAndFeedback": { "message": "Hulp en feedback" },
+  "commonHelpAndFeedback": { "message": "Help & Feedback" },
   "commonFloatingMode": { "message": "Zwevende modus" },
+  "commonStorageUsage": { "message": "Opslaggebruik" },
   "commonSettings": { "message": "Instellingen" },
-  "commonProfile": { "message": "Profiel" }
+  "commonProfile": { "message": "Profiel" },
+  "commonManageSubscription": { "message": "Abonnement beheren" },
+  "commonSignOut": { "message": "Uitloggen" },
+  "commonOpenWebApp": { "message": "Webapp openen" },
+  "commonAll": { "message": "Alles" },
+  "commonFavorites": { "message": "Favorieten" },
+  "commonCloud": { "message": "Cloud" }
 }

--- a/locales/no/messages.json
+++ b/locales/no/messages.json
@@ -1,0 +1,15 @@
+{
+  "commonChangelog": { "message": "Endringslogg" },
+  "commonSupportDevelopment": { "message": "Støtt utviklingen" },
+  "commonHelpAndFeedback": { "message": "Hjelp og tilbakemelding" },
+  "commonFloatingMode": { "message": "Flytende modus" },
+  "commonStorageUsage": { "message": "Lagringsbruk" },
+  "commonSettings": { "message": "Innstillinger" },
+  "commonProfile": { "message": "Profil" },
+  "commonManageSubscription": { "message": "Administrer abonnement" },
+  "commonSignOut": { "message": "Logg ut" },
+  "commonOpenWebApp": { "message": "Åpne nettapp" },
+  "commonAll": { "message": "Alle" },
+  "commonFavorites": { "message": "Favoritter" },
+  "commonCloud": { "message": "Sky" }
+}

--- a/locales/pl/messages.json
+++ b/locales/pl/messages.json
@@ -1,8 +1,15 @@
 {
-  "commonChangelog": { "message": "Dziennik zmian" },
+  "commonChangelog": { "message": "Lista zmian" },
   "commonSupportDevelopment": { "message": "Wsparcie rozwoju" },
   "commonHelpAndFeedback": { "message": "Pomoc i opinie" },
   "commonFloatingMode": { "message": "Tryb pływający" },
+  "commonStorageUsage": { "message": "Wykorzystanie pamięci" },
   "commonSettings": { "message": "Ustawienia" },
-  "commonProfile": { "message": "Profil" }
+  "commonProfile": { "message": "Profil" },
+  "commonManageSubscription": { "message": "Zarządzaj subskrypcją" },
+  "commonSignOut": { "message": "Wyloguj się" },
+  "commonOpenWebApp": { "message": "Otwórz aplikację internetową" },
+  "commonAll": { "message": "Wszystkie" },
+  "commonFavorites": { "message": "Ulubione" },
+  "commonCloud": { "message": "Chmura" }
 }

--- a/locales/pt_BR/messages.json
+++ b/locales/pt_BR/messages.json
@@ -1,8 +1,15 @@
 {
   "commonChangelog": { "message": "Registro de alterações" },
-  "commonSupportDevelopment": { "message": "Desenvolvimento de suporte" },
-  "commonHelpAndFeedback": { "message": "Ajuda e comentários" },
+  "commonSupportDevelopment": { "message": "Apoie o desenvolvimento" },
+  "commonHelpAndFeedback": { "message": "Ajuda e Feedback" },
   "commonFloatingMode": { "message": "Modo flutuante" },
+  "commonStorageUsage": { "message": "Uso de armazenamento" },
   "commonSettings": { "message": "Configurações" },
-  "commonProfile": { "message": "Perfil do usuário" }
+  "commonProfile": { "message": "Perfil" },
+  "commonManageSubscription": { "message": "Gerenciar assinatura" },
+  "commonSignOut": { "message": "Sair" },
+  "commonOpenWebApp": { "message": "Abrir aplicativo web" },
+  "commonAll": { "message": "Tudo" },
+  "commonFavorites": { "message": "Favoritos" },
+  "commonCloud": { "message": "Nuvem" }
 }

--- a/locales/pt_PT/messages.json
+++ b/locales/pt_PT/messages.json
@@ -1,8 +1,15 @@
 {
   "commonChangelog": { "message": "Registo de alterações" },
-  "commonSupportDevelopment": { "message": "Desenvolvimento de suporte" },
+  "commonSupportDevelopment": { "message": "Apoio ao desenvolvimento" },
   "commonHelpAndFeedback": { "message": "Ajuda e comentários" },
   "commonFloatingMode": { "message": "Modo flutuante" },
+  "commonStorageUsage": { "message": "Utilização de armazenamento" },
   "commonSettings": { "message": "Definições" },
-  "commonProfile": { "message": "Perfil do utilizador" }
+  "commonProfile": { "message": "Perfil" },
+  "commonManageSubscription": { "message": "Gerir subscrição" },
+  "commonSignOut": { "message": "Sair" },
+  "commonOpenWebApp": { "message": "Abrir aplicação web" },
+  "commonAll": { "message": "Todos" },
+  "commonFavorites": { "message": "Favoritos" },
+  "commonCloud": { "message": "Nuvem" }
 }

--- a/locales/ro/messages.json
+++ b/locales/ro/messages.json
@@ -1,8 +1,15 @@
 {
-  "commonChangelog": { "message": "Jurnal de schimbări" },
-  "commonSupportDevelopment": { "message": "Asistență pentru dezvoltare" },
+  "commonChangelog": { "message": "Jurnal de modificări" },
+  "commonSupportDevelopment": { "message": "Dezvoltare asistență" },
   "commonHelpAndFeedback": { "message": "Ajutor și feedback" },
-  "commonFloatingMode": { "message": "Modul plutitor" },
+  "commonFloatingMode": { "message": "Mod flotant" },
+  "commonStorageUsage": { "message": "Utilizarea spațiului de stocare" },
   "commonSettings": { "message": "Setări" },
-  "commonProfile": { "message": "Profil" }
+  "commonProfile": { "message": "Profil" },
+  "commonManageSubscription": { "message": "Gestionare abonament" },
+  "commonSignOut": { "message": "Deconectare" },
+  "commonOpenWebApp": { "message": "Deschide aplicația web" },
+  "commonAll": { "message": "Toate" },
+  "commonFavorites": { "message": "Favorite" },
+  "commonCloud": { "message": "Cloud" }
 }

--- a/locales/ru/messages.json
+++ b/locales/ru/messages.json
@@ -1,8 +1,15 @@
 {
-  "commonChangelog": { "message": "Changelog" },
+  "commonChangelog": { "message": "Журнал изменений" },
   "commonSupportDevelopment": { "message": "Поддержка разработки" },
-  "commonHelpAndFeedback": { "message": "Помощь и отзывы" },
+  "commonHelpAndFeedback": { "message": "Справка и отзывы" },
   "commonFloatingMode": { "message": "Плавающий режим" },
+  "commonStorageUsage": { "message": "Использование памяти" },
   "commonSettings": { "message": "Настройки" },
-  "commonProfile": { "message": "Профиль" }
+  "commonProfile": { "message": "Профиль" },
+  "commonManageSubscription": { "message": "Управление подпиской" },
+  "commonSignOut": { "message": "Выйти" },
+  "commonOpenWebApp": { "message": "Открыть веб-приложение" },
+  "commonAll": { "message": "Все" },
+  "commonFavorites": { "message": "Избранное" },
+  "commonCloud": { "message": "Облако" }
 }

--- a/locales/sk/messages.json
+++ b/locales/sk/messages.json
@@ -1,8 +1,15 @@
 {
   "commonChangelog": { "message": "Zoznam zmien" },
-  "commonSupportDevelopment": { "message": "Vývoj podpory" },
+  "commonSupportDevelopment": { "message": "Podpora vývoja" },
   "commonHelpAndFeedback": { "message": "Pomoc a spätná väzba" },
   "commonFloatingMode": { "message": "Plávajúci režim" },
+  "commonStorageUsage": { "message": "Využitie úložného priestoru" },
   "commonSettings": { "message": "Nastavenia" },
-  "commonProfile": { "message": "Profil" }
+  "commonProfile": { "message": "Profil" },
+  "commonManageSubscription": { "message": "Spravovať predplatné" },
+  "commonSignOut": { "message": "Odhlásiť sa" },
+  "commonOpenWebApp": { "message": "Otvoriť webovú aplikáciu" },
+  "commonAll": { "message": "Všetko" },
+  "commonFavorites": { "message": "Obľúbené" },
+  "commonCloud": { "message": "Cloud" }
 }

--- a/locales/sl/messages.json
+++ b/locales/sl/messages.json
@@ -1,8 +1,15 @@
 {
   "commonChangelog": { "message": "Seznam sprememb" },
-  "commonSupportDevelopment": { "message": "Razvoj podpore" },
+  "commonSupportDevelopment": { "message": "Podpora razvoju" },
   "commonHelpAndFeedback": { "message": "Pomoč in povratne informacije" },
   "commonFloatingMode": { "message": "Plavajoči način" },
+  "commonStorageUsage": { "message": "Poraba prostora" },
   "commonSettings": { "message": "Nastavitve" },
-  "commonProfile": { "message": "Profil" }
+  "commonProfile": { "message": "Profil" },
+  "commonManageSubscription": { "message": "Upravljanje naročnine" },
+  "commonSignOut": { "message": "Odjavi se" },
+  "commonOpenWebApp": { "message": "Odpri spletno aplikacijo" },
+  "commonAll": { "message": "Vse" },
+  "commonFavorites": { "message": "Priljubljene" },
+  "commonCloud": { "message": "Oblak" }
 }

--- a/locales/sr/messages.json
+++ b/locales/sr/messages.json
@@ -1,0 +1,15 @@
+{
+  "commonChangelog": { "message": "Лог промена" },
+  "commonSupportDevelopment": { "message": "Подржите развој" },
+  "commonHelpAndFeedback": { "message": "Помоћ и повратне информације" },
+  "commonFloatingMode": { "message": "Пловијући режим" },
+  "commonStorageUsage": { "message": "Употреба простора за складиштење" },
+  "commonSettings": { "message": "Подешавања" },
+  "commonProfile": { "message": "Профил" },
+  "commonManageSubscription": { "message": "Управљање претплатом" },
+  "commonSignOut": { "message": "Одјавите се" },
+  "commonOpenWebApp": { "message": "Отвори веб апликацију" },
+  "commonAll": { "message": "Сви" },
+  "commonFavorites": { "message": "Омиљени" },
+  "commonCloud": { "message": "Облак" }
+}

--- a/locales/sv/messages.json
+++ b/locales/sv/messages.json
@@ -1,8 +1,15 @@
 {
-  "commonChangelog": { "message": "Changelog" },
+  "commonChangelog": { "message": "Ändringslogg" },
   "commonSupportDevelopment": { "message": "Stöd för utveckling" },
   "commonHelpAndFeedback": { "message": "Hjälp och feedback" },
   "commonFloatingMode": { "message": "Flytande läge" },
+  "commonStorageUsage": { "message": "Lagringsanvändning" },
   "commonSettings": { "message": "Inställningar" },
-  "commonProfile": { "message": "Profil" }
+  "commonProfile": { "message": "Profil" },
+  "commonManageSubscription": { "message": "Hantera prenumeration" },
+  "commonSignOut": { "message": "Logga ut" },
+  "commonOpenWebApp": { "message": "Öppna webbappen" },
+  "commonAll": { "message": "Alla" },
+  "commonFavorites": { "message": "Favoriter" },
+  "commonCloud": { "message": "Molnet" }
 }

--- a/locales/sw/messages.json
+++ b/locales/sw/messages.json
@@ -1,0 +1,15 @@
+{
+  "commonChangelog": { "message": "Orodha ya mabadiliko" },
+  "commonSupportDevelopment": { "message": "Saidia Maendeleo" },
+  "commonHelpAndFeedback": { "message": "Msaada na Maoni" },
+  "commonFloatingMode": { "message": "Hali ya Kuelea" },
+  "commonStorageUsage": { "message": "Matumizi ya Hifadhi" },
+  "commonSettings": { "message": "Mipangilio" },
+  "commonProfile": { "message": "Profaili" },
+  "commonManageSubscription": { "message": "Dhibiti Usajili" },
+  "commonSignOut": { "message": "Toka" },
+  "commonOpenWebApp": { "message": "Fungua Programu ya Wavuti" },
+  "commonAll": { "message": "Zote" },
+  "commonFavorites": { "message": "Vipendwa" },
+  "commonCloud": { "message": "Wingu" }
+}

--- a/locales/ta/messages.json
+++ b/locales/ta/messages.json
@@ -1,0 +1,17 @@
+{
+  "commonChangelog": { "message": "மாற்றப் பதிவு" },
+  "commonSupportDevelopment": { "message": "மேம்பாட்டிற்கு ஆதரவளியுங்கள்" },
+  "commonHelpAndFeedback": { "message": "உதவி மற்றும் கருத்து" },
+  "commonFloatingMode": { "message": "தெப்பும் முறை" },
+  "commonStorageUsage": { "message": "சேமிப்பகப் பயன்பாடு" },
+  "commonSettings": { "message": "அமைப்புகள்" },
+  "commonProfile": { "message": "சுயவிவரம்" },
+  "commonManageSubscription": { "message": "சந்தாவை நிர்வகிக்கவும்" },
+  "commonSignOut": { "message": "வெளியேறு" },
+  "commonOpenWebApp": {
+    "message": "புதிய உலாவிப் பக்கத்தில் செயலியின் இணையப் பதிப்பைத் திறக்கவும்"
+  },
+  "commonAll": { "message": "அனைத்தும்" },
+  "commonFavorites": { "message": "பிடித்தவை" },
+  "commonCloud": { "message": "கிளவுட்" }
+}

--- a/locales/te/messages.json
+++ b/locales/te/messages.json
@@ -1,0 +1,15 @@
+{
+  "commonChangelog": { "message": "మార్పుల జాబితా" },
+  "commonSupportDevelopment": { "message": "అభివృద్ధికి మద్దతు" },
+  "commonHelpAndFeedback": { "message": "సహాయం & అభిప్రాయం" },
+  "commonFloatingMode": { "message": "ఫ్లోటింగ్ మోడ్" },
+  "commonStorageUsage": { "message": "నిల్వ వినియోగం" },
+  "commonSettings": { "message": "సెట్టింగ్‌లు" },
+  "commonProfile": { "message": "ప్రొఫైల్" },
+  "commonManageSubscription": { "message": "చందాను నిర్వహించండి" },
+  "commonSignOut": { "message": "సైన్ అవుట్" },
+  "commonOpenWebApp": { "message": "వెబ్ యాప్‌ను తెరవండి" },
+  "commonAll": { "message": "అన్నీ" },
+  "commonFavorites": { "message": "ఇష్టమైనవి" },
+  "commonCloud": { "message": "క్లౌడ్" }
+}

--- a/locales/th/messages.json
+++ b/locales/th/messages.json
@@ -1,0 +1,15 @@
+{
+  "commonChangelog": { "message": "บันทึกการเปลี่ยนแปลง" },
+  "commonSupportDevelopment": { "message": "สนับสนุนการพัฒนา" },
+  "commonHelpAndFeedback": { "message": "ความช่วยเหลือและข้อเสนอแนะ" },
+  "commonFloatingMode": { "message": "โหมดลอย" },
+  "commonStorageUsage": { "message": "การใช้งานพื้นที่จัดเก็บ" },
+  "commonSettings": { "message": "การตั้งค่า" },
+  "commonProfile": { "message": "โปรไฟล์" },
+  "commonManageSubscription": { "message": "จัดการการสมัครสมาชิก" },
+  "commonSignOut": { "message": "ลงชื่อออก" },
+  "commonOpenWebApp": { "message": "แอปเว็บแบบเปิด" },
+  "commonAll": { "message": "ทั้งหมด" },
+  "commonFavorites": { "message": "รายการโปรด" },
+  "commonCloud": { "message": "คลาวด์" }
+}

--- a/locales/tr/messages.json
+++ b/locales/tr/messages.json
@@ -1,8 +1,15 @@
 {
-  "commonChangelog": { "message": "Değişiklik Günlüğü" },
-  "commonSupportDevelopment": { "message": "Destek Geliştirme" },
+  "commonChangelog": { "message": "Değişiklik günlüğü" },
+  "commonSupportDevelopment": { "message": "Geliştirme Desteği" },
   "commonHelpAndFeedback": { "message": "Yardım ve Geri Bildirim" },
-  "commonFloatingMode": { "message": "Kayan Mod" },
+  "commonFloatingMode": { "message": "Yüzen Mod" },
+  "commonStorageUsage": { "message": "Depolama Alanı Kullanımı" },
   "commonSettings": { "message": "Ayarlar" },
-  "commonProfile": { "message": "Profil" }
+  "commonProfile": { "message": "Profil" },
+  "commonManageSubscription": { "message": "Aboneliği Yönet" },
+  "commonSignOut": { "message": "Oturumu Kapat" },
+  "commonOpenWebApp": { "message": "Web Uygulamasını Aç" },
+  "commonAll": { "message": "Tümü" },
+  "commonFavorites": { "message": "Favoriler" },
+  "commonCloud": { "message": "Bulut" }
 }

--- a/locales/uk/messages.json
+++ b/locales/uk/messages.json
@@ -1,8 +1,15 @@
 {
   "commonChangelog": { "message": "Журнал змін" },
-  "commonSupportDevelopment": { "message": "Підтримати розробку" },
+  "commonSupportDevelopment": { "message": "Підтримка розробки" },
   "commonHelpAndFeedback": { "message": "Допомога та відгуки" },
   "commonFloatingMode": { "message": "Плаваючий режим" },
+  "commonStorageUsage": { "message": "Використання пам'яті" },
   "commonSettings": { "message": "Налаштування" },
-  "commonProfile": { "message": "Профіль" }
+  "commonProfile": { "message": "Профіль" },
+  "commonManageSubscription": { "message": "Керувати передплатою" },
+  "commonSignOut": { "message": "Вийти" },
+  "commonOpenWebApp": { "message": "Відкрити веб-додаток" },
+  "commonAll": { "message": "Усі" },
+  "commonFavorites": { "message": "Вибране" },
+  "commonCloud": { "message": "Хмара" }
 }

--- a/locales/vi/messages.json
+++ b/locales/vi/messages.json
@@ -1,0 +1,15 @@
+{
+  "commonChangelog": { "message": "Nhật ký thay đổi" },
+  "commonSupportDevelopment": { "message": "Hỗ trợ phát triển" },
+  "commonHelpAndFeedback": { "message": "Trợ giúp & Phản hồi" },
+  "commonFloatingMode": { "message": "Chế độ nổi" },
+  "commonStorageUsage": { "message": "Sử dụng bộ nhớ" },
+  "commonSettings": { "message": "Cài đặt" },
+  "commonProfile": { "message": "Hồ sơ" },
+  "commonManageSubscription": { "message": "Quản lý đăng ký" },
+  "commonSignOut": { "message": "Đăng xuất" },
+  "commonOpenWebApp": { "message": "Mở Ứng dụng Web" },
+  "commonAll": { "message": "Tất cả" },
+  "commonFavorites": { "message": "Yêu thích" },
+  "commonCloud": { "message": "Đám mây" }
+}

--- a/locales/zh_CN/messages.json
+++ b/locales/zh_CN/messages.json
@@ -3,6 +3,13 @@
   "commonSupportDevelopment": { "message": "支持开发" },
   "commonHelpAndFeedback": { "message": "帮助与反馈" },
   "commonFloatingMode": { "message": "浮动模式" },
+  "commonStorageUsage": { "message": "存储使用情况" },
   "commonSettings": { "message": "设置" },
-  "commonProfile": { "message": "简介" }
+  "commonProfile": { "message": "个人资料" },
+  "commonManageSubscription": { "message": "管理订阅" },
+  "commonSignOut": { "message": "注销" },
+  "commonOpenWebApp": { "message": "打开 Web 应用" },
+  "commonAll": { "message": "全部" },
+  "commonFavorites": { "message": "收藏" },
+  "commonCloud": { "message": "云" }
 }

--- a/locales/zh_TW/messages.json
+++ b/locales/zh_TW/messages.json
@@ -1,8 +1,15 @@
 {
-  "commonChangelog": { "message": "更新日志" },
-  "commonSupportDevelopment": { "message": "支持开发" },
-  "commonHelpAndFeedback": { "message": "帮助与反馈" },
-  "commonFloatingMode": { "message": "浮动模式" },
-  "commonSettings": { "message": "设置" },
-  "commonProfile": { "message": "简介" }
+  "commonChangelog": { "message": "變更紀錄" },
+  "commonSupportDevelopment": { "message": "支持開發" },
+  "commonHelpAndFeedback": { "message": "說明與回饋" },
+  "commonFloatingMode": { "message": "浮動模式" },
+  "commonStorageUsage": { "message": "儲存空間使用量" },
+  "commonSettings": { "message": "設定" },
+  "commonProfile": { "message": "個人檔案" },
+  "commonManageSubscription": { "message": "管理訂閱" },
+  "commonSignOut": { "message": "登出" },
+  "commonOpenWebApp": { "message": "開啟網頁應用程式" },
+  "commonAll": { "message": "全部" },
+  "commonFavorites": { "message": "收藏" },
+  "commonCloud": { "message": "雲端" }
 }

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "package:firefox": "plasmo package --target=firefox-mv2",
     "lint": "eslint .",
     "format": "prettier . --write",
-    "generate:translations": "ts-node scripts/generate-translations.ts"
+    "generate:translations": "DOTENV_CONFIG_PATH=.env.local ts-node -r dotenv/config scripts/generate-translations.ts"
   },
   "dependencies": {
     "@dnd-kit/core": "^6.1.0",
@@ -35,7 +35,6 @@
     "@ricokahler/pool": "^1.2.0",
     "@tabler/icons-react": "^3.14.0",
     "date-fns": "3.1.0",
-    "deepl-node": "^1.17.3",
     "jotai": "^2.9.3",
     "plasmo": "0.89.1",
     "react": "18.2.0",
@@ -58,6 +57,8 @@
     "@types/react": "18.2.48",
     "@types/react-dom": "18.2.18",
     "@types/react-window": "^1.8.8",
+    "deepl-node": "^1.27.0",
+    "dotenv": "^17.3.1",
     "eslint": "^9.16.0",
     "prettier": "3.2.4",
     "ts-node": "^10.9.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -59,9 +59,6 @@ dependencies:
   date-fns:
     specifier: 3.1.0
     version: 3.1.0
-  deepl-node:
-    specifier: ^1.17.3
-    version: 1.17.3
   jotai:
     specifier: ^2.9.3
     version: 2.9.3(@types/react@18.2.48)(react@18.2.0)
@@ -124,6 +121,12 @@ devDependencies:
   "@types/react-window":
     specifier: ^1.8.8
     version: 1.8.8
+  deepl-node:
+    specifier: ^1.27.0
+    version: 1.27.0
+  dotenv:
+    specifier: ^17.3.1
+    version: 17.4.2
   eslint:
     specifier: ^9.16.0
     version: 9.16.0
@@ -4595,7 +4598,7 @@ packages:
         integrity: sha512-TGw5yVi4saajsSEgz25grObGHEUaDrniwvA2qwSC060KfqGPdglhvPMA2lPIoxs3PQIItj2iag35fONcQqgUaQ==,
       }
     engines: { node: ">=12.0" }
-    dev: false
+    dev: true
 
   /ajv@6.12.6:
     resolution:
@@ -4723,7 +4726,7 @@ packages:
       {
         integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==,
       }
-    dev: false
+    dev: true
 
   /axios@1.8.4:
     resolution:
@@ -4736,7 +4739,7 @@ packages:
       proxy-from-env: 1.1.0
     transitivePeerDependencies:
       - debug
-    dev: false
+    dev: true
 
   /axobject-query@3.2.4:
     resolution:
@@ -5011,7 +5014,6 @@ packages:
     dependencies:
       es-errors: 1.3.0
       function-bind: 1.1.2
-    dev: false
 
   /call-bind@1.0.7:
     resolution:
@@ -5020,10 +5022,10 @@ packages:
       }
     engines: { node: ">= 0.4" }
     dependencies:
-      es-define-property: 1.0.0
+      es-define-property: 1.0.1
       es-errors: 1.3.0
       function-bind: 1.1.2
-      get-intrinsic: 1.2.4
+      get-intrinsic: 1.3.0
       set-function-length: 1.2.2
     dev: false
 
@@ -5245,7 +5247,7 @@ packages:
     engines: { node: ">= 0.8" }
     dependencies:
       delayed-stream: 1.0.0
-    dev: false
+    dev: true
 
   /commander@4.1.1:
     resolution:
@@ -5495,22 +5497,21 @@ packages:
       }
     dev: true
 
-  /deepl-node@1.17.3:
+  /deepl-node@1.27.0:
     resolution:
       {
-        integrity: sha512-1Gbsz7tSAQ43VrwTHk8ttkPwRrTu0SRt461JgRzk0W5zeCf9sMRkg3svbc6357x+B4+UZ/2PU/sOOG5b+ywIWg==,
+        integrity: sha512-OEiprFdxqr7aS0+gmv8vsZLBLoDarBppG1zkTWUlrAvPoYdwSWKFWjcZgr9XSV3FWlPy8g10WdJjWkxDn9P56w==,
       }
-    engines: { node: ">=12.0" }
+    engines: { node: ">=14.17" }
     dependencies:
       "@types/node": 20.11.5
       adm-zip: 0.5.16
       axios: 1.8.4
-      form-data: 3.0.3
+      form-data: 3.0.5
       loglevel: 1.9.2
-      uuid: 8.3.2
     transitivePeerDependencies:
       - debug
-    dev: false
+    dev: true
 
   /deepmerge@4.3.1:
     resolution:
@@ -5544,9 +5545,9 @@ packages:
       }
     engines: { node: ">= 0.4" }
     dependencies:
-      es-define-property: 1.0.0
+      es-define-property: 1.0.1
       es-errors: 1.3.0
-      gopd: 1.0.1
+      gopd: 1.2.0
     dev: false
 
   /delayed-stream@1.0.0:
@@ -5555,7 +5556,7 @@ packages:
         integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==,
       }
     engines: { node: ">=0.4.0" }
-    dev: false
+    dev: true
 
   /dequal@2.0.3:
     resolution:
@@ -5678,6 +5679,14 @@ packages:
     engines: { node: ">=12" }
     dev: false
 
+  /dotenv@17.4.2:
+    resolution:
+      {
+        integrity: sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==,
+      }
+    engines: { node: ">=12" }
+    dev: true
+
   /dotenv@7.0.0:
     resolution:
       {
@@ -5696,7 +5705,6 @@ packages:
       call-bind-apply-helpers: 1.0.2
       es-errors: 1.3.0
       gopd: 1.2.0
-    dev: false
 
   /eastasianwidth@0.2.0:
     resolution:
@@ -5786,23 +5794,12 @@ packages:
       is-arrayish: 0.2.1
     dev: false
 
-  /es-define-property@1.0.0:
-    resolution:
-      {
-        integrity: sha512-jxayLKShrEqqzJ0eumQbVhTYQM27CfT1T35+gCgDFoL82JLsXqTJ76zv6A0YLOgEnLUMvLzsDsGIrl8NFpT2gQ==,
-      }
-    engines: { node: ">= 0.4" }
-    dependencies:
-      get-intrinsic: 1.2.4
-    dev: false
-
   /es-define-property@1.0.1:
     resolution:
       {
         integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==,
       }
     engines: { node: ">= 0.4" }
-    dev: false
 
   /es-errors@1.3.0:
     resolution:
@@ -5810,7 +5807,6 @@ packages:
         integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==,
       }
     engines: { node: ">= 0.4" }
-    dev: false
 
   /es-object-atoms@1.1.1:
     resolution:
@@ -5820,7 +5816,6 @@ packages:
     engines: { node: ">= 0.4" }
     dependencies:
       es-errors: 1.3.0
-    dev: false
 
   /es-set-tostringtag@2.1.0:
     resolution:
@@ -5832,8 +5827,8 @@ packages:
       es-errors: 1.3.0
       get-intrinsic: 1.3.0
       has-tostringtag: 1.0.2
-      hasown: 2.0.2
-    dev: false
+      hasown: 2.0.4
+    dev: true
 
   /esbuild@0.18.20:
     resolution:
@@ -6225,7 +6220,7 @@ packages:
     peerDependenciesMeta:
       debug:
         optional: true
-    dev: false
+    dev: true
 
   /foreground-child@3.3.0:
     resolution:
@@ -6246,18 +6241,19 @@ packages:
     engines: { node: ">= 14.17" }
     dev: false
 
-  /form-data@3.0.3:
+  /form-data@3.0.5:
     resolution:
       {
-        integrity: sha512-q5YBMeWy6E2Un0nMGWMgI65MAKtaylxfNJGJxpGh45YDciZB4epbWpaAfImil6CPAPTYB4sh0URQNDRIZG5F2w==,
+        integrity: sha512-j23EibVLnp4zNXGW7LjryXYa2X6U/M96yoOX+ybZxwkYajdxRNEqYY3zhh7y0i6kfISKS2jr+EJq1YTUDEv5+w==,
       }
     engines: { node: ">= 6" }
     dependencies:
       asynckit: 0.4.0
       combined-stream: 1.0.8
       es-set-tostringtag: 2.1.0
+      hasown: 2.0.4
       mime-types: 2.1.35
-    dev: false
+    dev: true
 
   /form-data@4.0.2:
     resolution:
@@ -6270,7 +6266,7 @@ packages:
       combined-stream: 1.0.8
       es-set-tostringtag: 2.1.0
       mime-types: 2.1.35
-    dev: false
+    dev: true
 
   /fs-constants@1.0.0:
     resolution:
@@ -6307,7 +6303,6 @@ packages:
       {
         integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==,
       }
-    dev: false
 
   /gensync@1.0.0-beta.2:
     resolution:
@@ -6315,20 +6310,6 @@ packages:
         integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==,
       }
     engines: { node: ">=6.9.0" }
-
-  /get-intrinsic@1.2.4:
-    resolution:
-      {
-        integrity: sha512-5uYhsJH8VJBTv7oslg4BznJYhDoRI6waYCxMmCdnTrcCrHA/fCFKoTFz2JKKE0HdDFUF7/oQuhzumXJK7paBRQ==,
-      }
-    engines: { node: ">= 0.4" }
-    dependencies:
-      es-errors: 1.3.0
-      function-bind: 1.1.2
-      has-proto: 1.0.3
-      has-symbols: 1.0.3
-      hasown: 2.0.2
-    dev: false
 
   /get-intrinsic@1.3.0:
     resolution:
@@ -6345,9 +6326,8 @@ packages:
       get-proto: 1.0.1
       gopd: 1.2.0
       has-symbols: 1.1.0
-      hasown: 2.0.2
+      hasown: 2.0.4
       math-intrinsics: 1.1.0
-    dev: false
 
   /get-nonce@1.0.1:
     resolution:
@@ -6374,7 +6354,6 @@ packages:
     dependencies:
       dunder-proto: 1.0.1
       es-object-atoms: 1.1.1
-    dev: false
 
   /get-stream@6.0.1:
     resolution:
@@ -6465,22 +6444,12 @@ packages:
       slash: 3.0.0
     dev: false
 
-  /gopd@1.0.1:
-    resolution:
-      {
-        integrity: sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==,
-      }
-    dependencies:
-      get-intrinsic: 1.2.4
-    dev: false
-
   /gopd@1.2.0:
     resolution:
       {
         integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==,
       }
     engines: { node: ">= 0.4" }
-    dev: false
 
   /got@12.6.1:
     resolution:
@@ -6580,23 +6549,7 @@ packages:
         integrity: sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==,
       }
     dependencies:
-      es-define-property: 1.0.0
-    dev: false
-
-  /has-proto@1.0.3:
-    resolution:
-      {
-        integrity: sha512-SJ1amZAJUiZS+PhsVLf5tGydlaVB8EdFpaSO4gmiUKUOxk8qzn5AIy4ZeJUmh22znIdk/uMAUT2pl3FxzVUH+Q==,
-      }
-    engines: { node: ">= 0.4" }
-    dev: false
-
-  /has-symbols@1.0.3:
-    resolution:
-      {
-        integrity: sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==,
-      }
-    engines: { node: ">= 0.4" }
+      es-define-property: 1.0.1
     dev: false
 
   /has-symbols@1.1.0:
@@ -6605,7 +6558,6 @@ packages:
         integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==,
       }
     engines: { node: ">= 0.4" }
-    dev: false
 
   /has-tostringtag@1.0.2:
     resolution:
@@ -6614,8 +6566,8 @@ packages:
       }
     engines: { node: ">= 0.4" }
     dependencies:
-      has-symbols: 1.0.3
-    dev: false
+      has-symbols: 1.1.0
+    dev: true
 
   /hasown@2.0.2:
     resolution:
@@ -6626,6 +6578,15 @@ packages:
     dependencies:
       function-bind: 1.1.2
     dev: false
+
+  /hasown@2.0.4:
+    resolution:
+      {
+        integrity: sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==,
+      }
+    engines: { node: ">= 0.4" }
+    dependencies:
+      function-bind: 1.1.2
 
   /hoist-non-react-statics@3.3.2:
     resolution:
@@ -7540,7 +7501,7 @@ packages:
         integrity: sha512-HgMmCqIJSAKqo68l0rS2AanEWfkxaZ5wNiEFb5ggm08lDs9Xl2KxBlX3PTcaD2chBM1gXAYf491/M2Rv8Jwayg==,
       }
     engines: { node: ">= 0.6.0" }
-    dev: false
+    dev: true
 
   /loose-envify@1.4.0:
     resolution:
@@ -7619,7 +7580,6 @@ packages:
         integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==,
       }
     engines: { node: ">= 0.4" }
-    dev: false
 
   /mdn-data@2.0.14:
     resolution:
@@ -7672,7 +7632,7 @@ packages:
         integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==,
       }
     engines: { node: ">= 0.6" }
-    dev: false
+    dev: true
 
   /mime-types@2.1.35:
     resolution:
@@ -7682,7 +7642,7 @@ packages:
     engines: { node: ">= 0.6" }
     dependencies:
       mime-db: 1.52.0
-    dev: false
+    dev: true
 
   /mime@1.6.0:
     resolution:
@@ -8497,7 +8457,7 @@ packages:
       {
         integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==,
       }
-    dev: false
+    dev: true
 
   /prr@1.0.1:
     resolution:
@@ -8992,8 +8952,8 @@ packages:
       define-data-property: 1.1.4
       es-errors: 1.3.0
       function-bind: 1.1.2
-      get-intrinsic: 1.2.4
-      gopd: 1.0.1
+      get-intrinsic: 1.3.0
+      gopd: 1.2.0
       has-property-descriptors: 1.0.2
     dev: false
 
@@ -9851,14 +9811,6 @@ packages:
         integrity: sha512-6Z7Ma2aVEWisaL6TvBCy7P8rm2LQoPv6dJ7ecIaIixHcwfbJ0x7mWdbcwlIM5IGQxPZSFYeqRCqlOOeKoJYMkw==,
       }
     engines: { node: ">= 4" }
-    dev: false
-
-  /uuid@8.3.2:
-    resolution:
-      {
-        integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==,
-      }
-    hasBin: true
     dev: false
 
   /uuid@9.0.1:

--- a/popup/App.tsx
+++ b/popup/App.tsx
@@ -247,7 +247,7 @@ export const App = () => {
                 <IconPictureInPicture size="1.125rem" />
               </ActionIcon>
             </Tooltip>
-            <Tooltip label={<Text fz="xs">Storage Usage</Text>}>
+            <Tooltip label={<Text fz="xs">{chrome.i18n.getMessage("commonStorageUsage")}</Text>}>
               <ActionIcon
                 variant="light"
                 color="indigo.5"
@@ -335,7 +335,7 @@ export const App = () => {
                 label: (
                   <Group align="center" spacing={4} noWrap>
                     <IconClipboardList size="1rem" />
-                    <Text>All</Text>
+                    <Text>{chrome.i18n.getMessage("commonAll")}</Text>
                   </Group>
                 ),
                 value: Tab.Enum.All,
@@ -344,7 +344,7 @@ export const App = () => {
                 label: (
                   <Group align="center" spacing={4} noWrap>
                     <IconStar size="1rem" />
-                    <Text>Favorites</Text>
+                    <Text>{chrome.i18n.getMessage("commonFavorites")}</Text>
                   </Group>
                 ),
                 value: Tab.Enum.Favorites,
@@ -353,7 +353,7 @@ export const App = () => {
                 label: (
                   <Group align="center" spacing={4} noWrap>
                     <IconCloud size="1rem" />
-                    <Text>Cloud</Text>
+                    <Text>{chrome.i18n.getMessage("commonCloud")}</Text>
                   </Group>
                 ),
                 value: Tab.Enum.Cloud,

--- a/popup/components/cloud/UserActionIcon.tsx
+++ b/popup/components/cloud/UserActionIcon.tsx
@@ -41,10 +41,10 @@ export const UserActionIcon = () => {
           href={`${env.BASE_URL}/checkout/${auth.user.id}`}
           target="_blank"
         >
-          <Text fz="xs">Manage Subscription</Text>
+          <Text fz="xs">{chrome.i18n.getMessage("commonManageSubscription")}</Text>
         </Menu.Item>
         <Menu.Item icon={<IconLogout size="0.8rem" />} onClick={() => db.auth.signOut()}>
-          <Text fz="xs">Sign Out</Text>
+          <Text fz="xs">{chrome.i18n.getMessage("commonSignOut")}</Text>
         </Menu.Item>
 
         <Menu.Divider />
@@ -55,7 +55,7 @@ export const UserActionIcon = () => {
           href="https://app.clipboardhistory.io"
           target="_blank"
         >
-          <Text fz="xs">Open Web App</Text>
+          <Text fz="xs">{chrome.i18n.getMessage("commonOpenWebApp")}</Text>
         </Menu.Item>
         <Menu.Item
           icon={<IconDeviceMobile size="0.8rem" />}

--- a/popup/components/modals/StorageUsageModalContent.tsx
+++ b/popup/components/modals/StorageUsageModalContent.tsx
@@ -41,7 +41,7 @@ export const StorageUsageModalContent = () => {
   return (
     <Paper p="md">
       <Group align="center" position="apart" mb="xs">
-        <Title order={5}>Storage Usage</Title>
+        <Title order={5}>{chrome.i18n.getMessage("commonStorageUsage")}</Title>
         <CloseButton onClick={() => modals.closeAll()} />
       </Group>
 

--- a/scripts/generate-translations.ts
+++ b/scripts/generate-translations.ts
@@ -66,116 +66,143 @@ const ALL_CHROME_I18N_LANGUAGE_CODES = [
 
 type ChromeI18nLanguageCode = (typeof ALL_CHROME_I18N_LANGUAGE_CODES)[number];
 
+// Maps a Chrome i18n locale to its DeepL target language, or null when DeepL
+// cannot translate it. Every returned code is a valid `TargetLanguageCode` as of
+// deepl-node 1.27.0 (which exposes DeepL's January 2026 language expansion), so
+// no type assertions are needed.
 const languageCodeChromeToDeepL = (
   langChrome: ChromeI18nLanguageCode,
 ): TargetLanguageCode | null => {
   switch (langChrome) {
+    // Not supported by DeepL.
     case "am":
-    case "bn":
-    case "ca":
-    case "fa":
-    case "fil":
-    case "gu":
-    case "he":
-    case "hi":
-    case "hr":
     case "kn":
-    case "ml":
-    case "mr":
-    case "ms":
-    case "no":
-    case "sr":
-    case "sw":
-    case "ta":
-    case "te":
-    case "th":
-    case "vi":
       return null;
 
+    // Chrome locales whose DeepL code differs from the Chrome code.
     case "en":
     case "en_US":
       return "en-US";
-
     case "en_AU":
     case "en_GB":
       return "en-GB";
-
     case "es_419":
-      return "es";
-
+      return "es-419";
     case "pt_BR":
       return "pt-BR";
-
     case "pt_PT":
       return "pt-PT";
-
     case "zh_CN":
+      return "zh-HANS";
     case "zh_TW":
-      return "zh";
+      return "zh-HANT";
+    case "fil":
+      return "tl"; // Filipino → Tagalog
+    case "no":
+      return "nb"; // Norwegian → Norwegian Bokmål
   }
 
+  // Every remaining Chrome code is itself a valid DeepL target code.
   return langChrome;
 };
 
 const getLocaleOverride = (lang: ChromeI18nLanguageCode) => {
-  if (!existsSync(path.join("locale-overrides", lang, "messages.json"))) {
+  const overridePath = path.join("locale-overrides", lang, "messages.json");
+  if (!existsSync(overridePath)) {
     return {};
   }
 
   return z
-    .record(
-      z.string(),
-      z.object({
-        message: z.string(),
-      }),
-    )
-    .parse(JSON.parse(readFileSync(path.join("locale-overrides", lang, "messages.json"), "utf8")));
+    .record(z.string(), z.object({ message: z.string() }))
+    .parse(JSON.parse(readFileSync(overridePath, "utf8")));
 };
 
 const writeMessagesJson = (lang: ChromeI18nLanguageCode, data: string) => {
-  if (!existsSync(path.join("locales", lang))) {
-    mkdirSync(path.join("locales", lang));
+  const dir = path.join("locales", lang);
+  if (!existsSync(dir)) {
+    mkdirSync(dir);
   }
 
-  writeFileSync(path.join("locales", lang, "messages.json"), data);
+  writeFileSync(path.join(dir, "messages.json"), data);
 };
 
-const translator = new Translator("b2c0e6a4-a0b7-46f8-82f1-2473d1e21355:fx");
+const authKey = process.env.DEEPL_API_KEY;
+if (!authKey) {
+  console.error("DEEPL_API_KEY environment variable is required.");
+  process.exit(1);
+}
 
-const languageCodeDeepLToMessagesJson: Record<string, Record<string, { message: string }>> = {};
+const translator = new Translator(authKey);
+
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+// DeepL aggressively rate limits the free tier, so retry transient failures with
+// exponential backoff before giving up.
+const translateText = async (message: string, description: string, lang: TargetLanguageCode) => {
+  for (let attempt = 0; ; attempt++) {
+    try {
+      const { text } = await translator.translateText(message, "en", lang, {
+        context: description,
+      });
+
+      // DeepL occasionally returns stray leading/trailing whitespace; UI labels
+      // never want it.
+      return text.trim();
+    } catch (e) {
+      if (attempt >= 5) {
+        throw e;
+      }
+
+      const delayMs = 2 ** attempt * 5000;
+      console.log(`  Rate limited on ${lang}, retrying in ${delayMs / 1000}s...`);
+      await sleep(delayMs);
+    }
+  }
+};
 
 const main = async () => {
-  const results = await pool({
-    collection: Array.from(
-      new Set(
-        ALL_CHROME_I18N_LANGUAGE_CODES.flatMap((lang) => {
-          const l = languageCodeChromeToDeepL(lang);
-          if (l === null) {
-            return [];
-          }
+  const messages = Object.entries(enMessagesJson);
 
-          return l;
-        }),
-      ),
+  const deepLLanguageCodes = Array.from(
+    new Set(
+      ALL_CHROME_I18N_LANGUAGE_CODES.flatMap((lang) => {
+        const l = languageCodeChromeToDeepL(lang);
+        return l === null ? [] : [l];
+      }),
     ),
+  );
+
+  // Optionally limit to N randomly-chosen languages for a quick sanity check,
+  // e.g. `pnpm generate:translations 3`.
+  const limit = Number(process.argv[2]);
+  const collection = Number.isNaN(limit)
+    ? deepLLanguageCodes
+    : deepLLanguageCodes.sort(() => Math.random() - 0.5).slice(0, limit);
+
+  console.log(`Translating ${messages.length} message(s) into ${collection.length} language(s)...`);
+
+  const results = await pool({
+    collection,
     maxConcurrency: 1,
     task: async (lang) => {
+      console.log(`Translating to ${lang}...`);
+
       return await pool({
-        collection: Object.entries(enMessagesJson),
+        collection: messages,
         maxConcurrency: 1,
         task: async ([key, { message, description }]) => {
-          const translation = await translator.translateText(message, "en", lang, {
-            context: description,
-          });
+          const text = await translateText(message, description, lang);
 
-          return [lang, { [key]: { message: translation.text } }] as const;
+          return [lang, { [key]: { message: text } }] as const;
         },
       });
     },
   });
 
-  results.flat().forEach(([key, val]) => {
-    languageCodeDeepLToMessagesJson[key] = { ...languageCodeDeepLToMessagesJson[key], ...val };
+  const languageCodeDeepLToMessagesJson: Record<string, Record<string, { message: string }>> = {};
+
+  results.flat().forEach(([lang, val]) => {
+    languageCodeDeepLToMessagesJson[lang] = { ...languageCodeDeepLToMessagesJson[lang], ...val };
   });
 
   ALL_CHROME_I18N_LANGUAGE_CODES.filter((lang) => lang !== "en").forEach((lang) => {
@@ -184,24 +211,27 @@ const main = async () => {
       return;
     }
 
-    const messagesJson = languageCodeDeepLToMessagesJson[l];
-    if (messagesJson === undefined) {
+    const translated = languageCodeDeepLToMessagesJson[l];
+    if (translated === undefined) {
       return;
     }
 
+    // Copy so that locales sharing a DeepL code (e.g. en_AU/en_GB → en-GB) don't
+    // leak each other's overrides into the shared translation object.
+    const messagesJson = { ...translated };
+
     const localeOverride = getLocaleOverride(lang);
-
     for (const key in enMessagesJson) {
-      const message = localeOverride[key];
-      if (message === undefined) {
-        continue;
+      const override = localeOverride[key];
+      if (override !== undefined) {
+        messagesJson[key] = override;
       }
-
-      messagesJson[key] = message;
     }
 
     writeMessagesJson(lang, JSON.stringify(messagesJson));
   });
+
+  console.log("Done!");
 };
 
 main();


### PR DESCRIPTION
## Summary

Integrates the i18n translation-generation upgrades from `defog-extension` and extends DeepL coverage further now that the library exposes DeepL's Jan-2026 language expansion. Also adds a few more translatable UI strings.

### Translation script (`scripts/generate-translations.ts`)
- **Security:** reads the DeepL key from `DEEPL_API_KEY` (via dotenv) instead of hardcoding it. Added `.env.example`.
- **More languages:** only Amharic (`am`) and Kannada (`kn`) remain unsupported by DeepL. 18 previously-skipped languages now translate: `hi, th, vi, he, bn, ca, fa, fil→tl, gu, hr, ml, mr, ms, no→nb, sr, sw, ta, te`.
- **Zero type casts:** bumping `deepl-node` to `1.27.0` means every mapped code is a real `TargetLanguageCode` literal — the Chrome→DeepL mapping is fully type-checked with no `as` assertions.
- **Correctness:** `zh_CN→zh-HANS` / `zh_TW→zh-HANT` (Simplified/Traditional split — previously both `zh`, which also leaked the zh_CN override into zh_TW), `es_419→es-419`, `no→nb`, `fil→tl`. Plus a copy-on-write fix so locales sharing a DeepL code can't leak overrides into each other.
- **Robustness:** retry-with-backoff on rate limits, trims stray DeepL whitespace, optional `pnpm generate:translations <N>` sanity-check mode.

### Dependencies
- `deepl-node` `^1.17.3 → ^1.27.0`, moved from `dependencies` to `devDependencies` (build-only).
- Added `dotenv` to `devDependencies`.

### New translatable strings
Added 7 tokens and wired them into the popup: `commonStorageUsage`, `commonAll` / `commonFavorites` / `commonCloud` (tab labels), `commonManageSubscription` / `commonSignOut` / `commonOpenWebApp` (profile menu). Regenerated all locale messages.

## Verification
- All 53 locales: valid UTF-8/JSON, every value `{message: string}`, full key parity with `en`, no empty messages, **no `$` placeholder hazards**, no control chars.
- Spot-checked: zh_CN override (`设置`) applied, zh_CN≠zh_TW, es≠es_419, new languages render in native script.
- **Chrome MV3 and Firefox MV2 both build cleanly**; built `_locales` matches source (53 dirs), `default_locale: en`, non-Latin content intact, and the DeepL key does not leak into either bundle.
- ESLint + Prettier clean on changed files.

## Follow-up
- Set `DEEPL_API_KEY` in `.env.local` to regenerate translations.
- The previously-hardcoded key still lives in git history — worth rotating it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
