### PR TITLE
fix: dismiss only the modal on Escape in the popup (Chromium CloseWatcher)

### DIFF
--- a/popup/App.tsx
+++ b/popup/App.tsx
@@ -57,6 +57,7 @@ import { useCloudEntriesQuery } from "./hooks/useCloudEntriesQuery";
 import { useCloudFavoritedEntriesQuery } from "./hooks/useCloudFavoritedEntriesQuery";
 import { useCloudTaggedEntriesQuery } from "./hooks/useCloudTaggedEntriesQuery";
 import { SEARCH_INPUT_ID } from "./hooks/useEntryListNavigation";
+import { useModalCloseRequestGuard } from "./hooks/useModalCloseRequestGuard";
 import { useSettingsQuery } from "./hooks/useSettingsQuery";
 import { useSubscriptionsQuery } from "./hooks/useSubscriptionsQuery";
 import { AllPage } from "./pages/AllPage";
@@ -74,6 +75,7 @@ import {
 
 export const App = () => {
   useApp();
+  useModalCloseRequestGuard();
 
   const theme = useMantineTheme();
 

--- a/popup/hooks/useModalCloseRequestGuard.ts
+++ b/popup/hooks/useModalCloseRequestGuard.ts
@@ -1,0 +1,42 @@
+import { useModals } from "@mantine/modals";
+import { useEffect } from "react";
+
+// In a Chrome popup the browser treats Escape (and the Android back gesture) as a "close
+// request" that dismisses the entire popup window — taking any open modal down with it.
+// `preventDefault()` on the keydown can't cancel a close request once focus has moved into the
+// modal, so instead we intercept the request with a CloseWatcher and dismiss only the top
+// modal, leaving the popup open. CloseWatcher is Chromium 120+; on older Chrome and on Firefox
+// (which disallows intercepting the popup-dismissing Escape by design) the popup keeps its
+// default behavior, which can't be overridden.
+declare global {
+  interface CloseWatcher extends EventTarget {
+    onclose: ((this: CloseWatcher, event: Event) => unknown) | null;
+    requestClose(): void;
+    close(): void;
+    destroy(): void;
+  }
+
+  interface Window {
+    CloseWatcher?: {
+      prototype: CloseWatcher;
+      new (options?: { signal?: AbortSignal }): CloseWatcher;
+    };
+  }
+}
+
+export const useModalCloseRequestGuard = () => {
+  const { modals, closeModal } = useModals();
+  const topModalId = modals[modals.length - 1]?.id;
+
+  useEffect(() => {
+    const CloseWatcher = window.CloseWatcher;
+    if (topModalId === undefined || CloseWatcher === undefined) {
+      return;
+    }
+
+    const watcher = new CloseWatcher();
+    watcher.onclose = () => closeModal(topModalId);
+
+    return () => watcher.destroy();
+  }, [topModalId, closeModal]);
+};


### PR DESCRIPTION
## Problem

In the **toolbar popup**, pressing <kbd>Escape</kbd> with a modal open closes the *entire extension window* instead of dismissing the modal.

## Root cause

Modern Chromium dismisses an extension popup via a **"close request"** — the same high-level signal as the Android back gesture — which is *separate* from a keydown's default action. So `event.preventDefault()` on the Escape keydown **cannot cancel it** once focus has moved into the modal's `<section role="dialog">`.

This is exactly why Escape-to-clear-search already works but Escape-to-close-modal didn't: a close request fired from a focused `<input>` (the search box) *is* cancelable via `preventDefault`, but one fired from the non-input modal is not. (Earlier `preventDefault`-based attempts therefore couldn't work — that approach is a dead end here.)

## Fix

While a modal is open, intercept the close request with a [`CloseWatcher`](https://developer.mozilla.org/en-US/docs/Web/API/CloseWatcher) and dismiss only the **top** modal, leaving the popup open. New hook `useModalCloseRequestGuard`, mounted once in `App`:

```ts
const { modals, closeModal } = useModals();
const topModalId = modals[modals.length - 1]?.id;

useEffect(() => {
  const CloseWatcher = window.CloseWatcher;
  if (topModalId === undefined || CloseWatcher === undefined) {
    return;
  }
  const watcher = new CloseWatcher();
  watcher.onclose = () => closeModal(topModalId);
  return () => watcher.destroy();
}, [topModalId, closeModal]);
```

`CloseWatcher` is the purpose-built API for intercepting close requests, so this works *with* the browser rather than fighting `preventDefault`.

## Compatibility (feature-detected, graceful)

| Surface | Behavior |
|---|---|
| Chromium 120+ toolbar popup | Escape dismisses the top modal, popup stays open |
| Chromium < 120 | `window.CloseWatcher` undefined → no-op, unchanged default behavior |
| Firefox | Mozilla [forbids intercepting the popup-dismissing Escape by design](https://bugzilla.mozilla.org/show_bug.cgi?id=1443758) (WONTFIX) → unchanged. **Cannot be fixed there.** |
| Side panel / floating window | No close-request-on-Escape to intercept → unaffected |

## Notes

- Closes only the top modal (`closeModal(id)`), so stacked modals (e.g. an error modal over settings) peel one layer at a time.
- `CloseWatcher` isn't in TS 5.3's `lib.dom.d.ts` yet, so the hook ships a minimal ambient declaration.

## Testing

- `pnpm lint` / `pnpm format` / `tsc` pass (the pre-existing `tsc` error in `utils/actionBadge.ts` is unrelated and on `main`).
- ⚠️ **Needs a manual smoke test in a loaded Chrome build** — a toolbar popup can't be driven by automation. Open a modal in the toolbar popup → Escape should dismiss the modal and keep the popup open; a second Escape (nothing open) closes the popup as usual.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
